### PR TITLE
라우터 구조 작업 & 테이블 구조 수정

### DIFF
--- a/src/entity/CommentEntity.ts
+++ b/src/entity/CommentEntity.ts
@@ -12,7 +12,7 @@ import {
 import User from './UserEntity';
 import Study from './StudyEntity';
 
-@Entity({ name: 'Comment' })
+@Entity({ name: 'COMMENT' })
 export default class Comment {
   @PrimaryGeneratedColumn('uuid', { name: 'ID' })
   id!: string;
@@ -34,6 +34,7 @@ export default class Comment {
   nestedComments!: Comment[];
 
   @ManyToOne(() => Comment, (comment) => comment.nestedComments)
+  @JoinColumn({ name: 'NESTED_COMMENT_ID' })
   parentComment!: Comment;
 
   @ManyToOne(() => Study, (study) => study.id)
@@ -41,6 +42,16 @@ export default class Comment {
   study!: Study;
 
   @ManyToMany(() => User)
-  @JoinTable({ name: 'USER_METOO_COMMENT' })
+  @JoinTable({
+    name: 'USER_METOO_COMMENT',
+    joinColumn: {
+      name: 'COMMENT_ID',
+      referencedColumnName: 'id',
+    },
+    inverseJoinColumn: {
+      name: 'USER_ID',
+      referencedColumnName: 'id',
+    },
+  })
   metooComment!: User[];
 }

--- a/src/entity/NotificationEntity.ts
+++ b/src/entity/NotificationEntity.ts
@@ -5,14 +5,29 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  PrimaryColumn,
 } from 'typeorm';
 import User from './UserEntity';
 import Study from './StudyEntity';
 
-@Entity({ name: 'Notification' })
+@Entity({ name: 'NOTIFICATION' })
 export default class Notification {
   @PrimaryGeneratedColumn('uuid', { name: 'ID' })
   id!: string;
+
+  @PrimaryColumn('uuid')
+  USER_ID!: string;
+
+  @ManyToOne(() => User, (user) => user.notifications)
+  @JoinColumn({ name: 'USER_ID' })
+  user!: User;
+
+  @PrimaryColumn('uuid')
+  STUDY_ID!: string;
+
+  @ManyToOne(() => Study, (study) => study.id)
+  @JoinColumn({ name: 'STUDY_ID' })
+  study!: Study;
 
   @Column({ name: 'TYPE' })
   type!: number;
@@ -22,12 +37,4 @@ export default class Notification {
 
   @CreateDateColumn({ name: 'CREATED_AT' })
   createdAt!: Date;
-
-  @ManyToOne(() => User, (user) => user.notifications)
-  @JoinColumn({ name: 'USER_ID' })
-  user!: User;
-
-  @ManyToOne(() => Study, (study) => study.id)
-  @JoinColumn({ name: 'STUDY_ID' })
-  study!: Study;
 }

--- a/src/entity/StudyEntity.ts
+++ b/src/entity/StudyEntity.ts
@@ -40,7 +40,7 @@ enum LocationEnum {
 
 @Entity({ name: 'STUDY' })
 export default class Study extends BaseEntity {
-  @PrimaryGeneratedColumn('uuid', { name: 'STUDY_ID' })
+  @PrimaryGeneratedColumn('uuid', { name: 'ID' })
   id!: string;
 
   @CreateDateColumn({ name: 'CREATED_AT' })
@@ -78,13 +78,23 @@ export default class Study extends BaseEntity {
   isOpen!: boolean;
 
   @OneToOne(() => Category, (category) => category.code)
-  @JoinTable()
+  @JoinColumn({ name: 'CATEGORY_CODE' })
   categoryCode!: Category;
 
   @Column('int', { name: 'VIEWS' })
   views!: number;
 
   @ManyToMany(() => User)
-  @JoinTable({ name: 'BOOKMARK' })
+  @JoinTable({
+    name: 'BOOKMARK',
+    joinColumn: {
+      name: 'STUDY_ID',
+      referencedColumnName: 'id',
+    },
+    inverseJoinColumn: {
+      name: 'USER_ID',
+      referencedColumnName: 'id',
+    },
+  })
   bookmarks!: User[];
 }

--- a/src/entity/StudyUserEntity.ts
+++ b/src/entity/StudyUserEntity.ts
@@ -1,0 +1,26 @@
+import { Entity, PrimaryColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import Study from './StudyEntity';
+import User from './UserEntity';
+
+@Entity({ name: 'STUDY_USER' })
+export default class StudyUser {
+  @PrimaryColumn('uuid')
+  USER_ID!: string;
+
+  @ManyToOne(() => User, (user) => user.id)
+  @JoinColumn({ name: 'USER_ID' })
+  user!: User;
+
+  @PrimaryColumn('uuid')
+  STUDY_ID!: string;
+
+  @ManyToOne(() => Study, (study) => study.id)
+  @JoinColumn({ name: 'STUDY_ID' })
+  study!: Study;
+
+  @Column({ name: 'IS_ACCEPTED' })
+  isAccepted!: boolean;
+
+  @Column({ name: 'TEMP_BIO' })
+  tempBio!: string;
+}

--- a/src/entity/UserEntity.ts
+++ b/src/entity/UserEntity.ts
@@ -8,7 +8,6 @@ import {
 } from 'typeorm';
 import Comment from './CommentEntity';
 import Notification from './NotificationEntity';
-import Study from './StudyEntity';
 import Category from './CategoryEntity';
 
 enum UserRoleEnum {
@@ -42,11 +41,17 @@ export default class User {
   @OneToMany(() => Comment, (comment) => comment.user)
   comments!: Comment[];
 
-  @ManyToMany(() => Study)
-  @JoinTable({ name: 'STUDY_USER' })
-  studies!: Study[];
-
   @ManyToMany(() => Category)
-  @JoinTable({ name: 'USER_INTEREST_CATEGORY' })
+  @JoinTable({
+    name: 'USER_INTEREST_CATEGORY',
+    joinColumn: {
+      name: 'USER_ID',
+      referencedColumnName: 'id',
+    },
+    inverseJoinColumn: {
+      name: 'CATEGORY_CODE',
+      referencedColumnName: 'code',
+    },
+  })
   categories!: Category[];
 }

--- a/src/entity/UserProfileEntity.ts
+++ b/src/entity/UserProfileEntity.ts
@@ -1,16 +1,14 @@
-import {
-  Column,
-  Entity,
-  JoinColumn,
-  OneToOne,
-  PrimaryGeneratedColumn,
-} from 'typeorm';
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
 import User from './UserEntity';
 
-@Entity({ name: 'UserProfile' })
+@Entity({ name: 'USER_PROFILE' })
 export default class UserProfile {
-  @PrimaryGeneratedColumn('uuid', { name: 'ID' })
-  id!: string;
+  @PrimaryColumn('uuid')
+  USER_ID!: string;
+
+  @OneToOne(() => User, (user) => user.id)
+  @JoinColumn({ name: 'USER_ID' })
+  id!: User;
 
   @Column({ name: 'USER_NAME' })
   userName!: string;
@@ -35,9 +33,6 @@ export default class UserProfile {
   @Column({ name: 'SHOW_GRADE' })
   showGrade!: boolean;
 
-  @Column({ name: 'SHOW_ABOUT' })
-  showAbout!: boolean;
-
   @Column({ name: 'ON_BREAK' })
   onBreak!: boolean;
 
@@ -55,8 +50,4 @@ export default class UserProfile {
 
   @Column({ name: 'LINK2' })
   link2!: string;
-
-  @OneToOne(() => User)
-  @JoinColumn({ name: 'USER_ID' })
-  user!: User;
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,12 @@
 import { Router } from 'express';
+import helloWorld from './hello-world';
 import userRouter from './user';
+import studyRouter from './study';
 
 const router = Router();
 router.use('/api/user', userRouter);
+router.use('/api/study', studyRouter);
+// 메인 페이지
+router.get('/api/', helloWorld);
 
 export default router;

--- a/src/routes/study/detail/index.ts
+++ b/src/routes/study/detail/index.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import helloWorld from '../../hello-world';
+
+const router = Router();
+router.get('/:id', helloWorld);
+
+export default router;

--- a/src/routes/study/id/index.ts
+++ b/src/routes/study/id/index.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import helloWorld from '../../hello-world';
+
+const router = Router();
+router.get('/', helloWorld);
+router.patch('/', helloWorld);
+router.delete('/', helloWorld);
+
+export default router;

--- a/src/routes/study/index.ts
+++ b/src/routes/study/index.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import helloWorld from '../hello-world';
+import idRouter from './id';
+import detailRouter from './detail';
+import userRouter from './user';
+
+const router = Router();
+router.get('/', helloWorld);
+router.post('/', helloWorld);
+router.use('/:id', idRouter);
+router.use('/detail', detailRouter);
+router.use('/user', userRouter);
+
+export default router;

--- a/src/routes/study/user/accept/index.ts
+++ b/src/routes/study/user/accept/index.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import helloWorld from '../../../hello-world';
+
+const router = Router();
+router.patch('/:id', helloWorld);
+
+export default router;

--- a/src/routes/study/user/id/index.ts
+++ b/src/routes/study/user/id/index.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import helloWorld from '../../../hello-world';
+
+const router = Router();
+router.get('/', helloWorld);
+router.post('/', helloWorld);
+router.patch('/', helloWorld);
+router.delete('/', helloWorld);
+
+export default router;

--- a/src/routes/study/user/index.ts
+++ b/src/routes/study/user/index.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import idRouter from './id';
+import acceptRouter from './accept';
+
+const router = Router();
+router.use('/:id', idRouter);
+router.use('/accept', acceptRouter);
+
+export default router;


### PR DESCRIPTION
이번에 라우터 구조 잡다 보니까 조금 비효율적인 부분이 보여서 고민 중인데, 제가 작업한 부분들 중에 user/role이나 study/detail, study/user/accept 관련 엔드포인트가 이제 처리해야 할 요청이 각각 1개씩이거든요. 굳이 따로 라우터 분리해서 불러와야 할까 싶어서 그냥 user랑 study 쪽에 라우팅해주자니 뭔가 나중에 지저분해질 수도 있을 것 같고 그렇다고 이대로 분리해서 두자니 조금 비효율적인것 같아서 고민이 되더라고요. 그래서 이 부분 관련해서 현민님은 어떻게 생각하시는지 이야기해주시면 감사하겠습니당

그리고 UserProfile 테이블에서 SHOW_ABOUT 칼럼은 없앴고요.

테이블 구조 수정한 부분들은 일단 저는 문제없이 잘 나왔고, 현민님도 한 번 빠진 부분이나 수정해야 할 부분 없는지 db 확인해주시면 될 것 같습니다!