### PR TITLE
회원가입 관련 api controller 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "NODE_ENV=test jest --detectOpenHandles --forceExit"
   },
   "dependencies": {
+    "bcrypt": "^5.0.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
@@ -26,6 +27,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/bcrypt": "^5.0.0",
     "@types/cookie-parser": "^1.4.2",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "rudy3091 <grayblack313@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "start:dev": "NODE_ENV=dev nodemon --watch 'src/**/*.ts' --ignore 'test/**' --exec 'ts-node src/index.ts'",
+    "start:dev": "NODE_ENV=dev nodemon --watch 'src/**/*.ts' --ext 'ts, js, json' --ignore 'test/**' --exec 'ts-node src/index.ts'",
     "test": "NODE_ENV=test jest --detectOpenHandles --forceExit"
   },
   "dependencies": {

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -6,6 +6,6 @@ export const db: ConnectionOptions = {
   username: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
-  synchronize: true,
+  synchronize: false,
   entities: [`${__dirname}/../entity/*.{ts,js}`],
 };

--- a/src/entity/UserEntity.ts
+++ b/src/entity/UserEntity.ts
@@ -10,8 +10,9 @@ import Comment from './CommentEntity';
 import Notification from './NotificationEntity';
 import Category from './CategoryEntity';
 
-enum UserRoleEnum {
+export enum UserRoleEnum {
   GUEST = 'GUEST',
+  USER = 'USER',
   ADMIN = 'ADMIN',
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import rootRouter from './routes';
 const swaggerSpec = swaggerJSDoc(swaggerOption);
 
 const app = express();
+app.use(express.json());
 app.use('/', rootRouter);
 app.use('/api-docs', swaggerUI.serve, swaggerUI.setup(swaggerSpec));
 

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -1,11 +1,11 @@
 import { Router } from 'express';
-import helloWorld from '../hello-world';
 import idRouter from './id';
 import roleRouter from './role';
 import profileRouter from './profile';
+import { saveUser } from '../../services/User';
 
 const router = Router();
-router.post('/', helloWorld);
+router.post('/', saveUser);
 router.use('/:id', idRouter);
 router.use('/role', roleRouter);
 router.use('/profile', profileRouter);

--- a/src/routes/user/role/index.ts
+++ b/src/routes/user/role/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
-import helloWorld from '../../hello-world';
+import { changeUserRole } from '../../../services/User';
 
 const router = Router();
-router.patch('/:id', helloWorld);
+router.patch('/:id', changeUserRole);
 
 export default router;

--- a/src/services/User/index.ts
+++ b/src/services/User/index.ts
@@ -4,6 +4,7 @@ import { Request, Response } from 'express';
 import { getRepository } from 'typeorm';
 import User, { UserRoleEnum } from '../../entity/UserEntity';
 import { makeSignUpToken } from '../../utils/auth';
+import jwt from 'jsonwebtoken';
 
 /**
  * @swagger
@@ -52,5 +53,76 @@ export const saveUser = async (req: Request, res: Response) => {
     res.status(201).json({ message: '회원가입 성공', id });
   } catch (e) {
     res.status(400).json({ message: '회원가입 실패: ' + (e as Error).message });
+  }
+};
+
+/**
+ * @swagger
+ * /user/role/:userid:
+ *  patch:
+ *    tags:
+ *    - user
+ *    summary: 사용자 권한 수정(회원가입 절차 마무리)
+ *    description: 회원가입을 요청한 사용자가 이메일에서 링크를 클릭해 학교메일을 인증할 시 사용될 api
+ *    parameters:
+ *    - in: path
+ *      name: userid
+ *      description: 회원가입하는 사용자의 id (요청 경로의 '-'를 허용해야하나?)
+ *      required: true
+ *      example: 15f6d6ee-32e2-4036-b050-fa79e38dcd36
+ *    - in: body
+ *      name: body
+ *      schema:
+ *        type: object
+ *        properties:
+ *          token:
+ *            type: string
+ *            example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjUxYjg0M2I5LWE5ZTEtNDk3Mi05NWNiLWVmYTcxYzY2ODI5NSIsImlhdCI6MTY0MDYzMDg2MiwiZXhwIjoxNjQwNzE3MjYyfQ.zLJtNN-VCuYlghtE2v0yDJbz7YuxedGHKLt6CW7tUnA
+ *            description: 사용자를 인증할 jwt토큰, email의 링크에 쿼리스트링으로 보내줄 예정
+ */
+export const changeUserRole = async (req: Request, res: Response) => {
+  const BAD_REQUEST = 'request is not valid';
+  const UNAUTHORIZED_ID = 'id not valid';
+  const UNAUTHORIZED_TOKEN = 'token is expired';
+  const NOT_FOUND = 'no user with given id found';
+  const OK = '사용자 권한 수정 성공';
+
+  try {
+    // TODO: id -> userid 로 수정
+    const id = req.params.id;
+    const { token } = req.body;
+    const decoded = jwt.verify(token, process.env.SIGNUP_TOKEN_SECRET!) as {
+      id: string;
+      exp: number;
+    };
+    if (decoded.id !== id) throw new Error(UNAUTHORIZED_ID);
+    if (decoded.exp * 1000 < Date.now()) throw new Error(UNAUTHORIZED_TOKEN);
+
+    const result = await getRepository(User)
+      .createQueryBuilder()
+      .update()
+      .set({
+        role: UserRoleEnum.USER,
+      })
+      .where('id = :id', { id })
+      .andWhere(`role = 'GUEST'`)
+      .execute();
+    if (!result.affected) throw new Error(NOT_FOUND);
+    res.json({
+      message: OK,
+      id,
+    });
+  } catch (e) {
+    if ((e as Error).message === NOT_FOUND) {
+      res
+        .status(404)
+        .json({ message: '회원가입 실패: ' + (e as Error).message });
+    } else if ((e as Error).message === UNAUTHORIZED_ID) {
+      res.status(403).json({ message: '회원가입 실패: ' + 'id 변조됨' });
+    } else if ((e as Error).message === UNAUTHORIZED_TOKEN) {
+      res.status(403).json({ message: '회원가입 실패: ' + UNAUTHORIZED_TOKEN });
+    } else {
+      res.status(400).json({ message: '회원가입 실패: ' + BAD_REQUEST });
+    }
   }
 };

--- a/src/services/User/index.ts
+++ b/src/services/User/index.ts
@@ -1,0 +1,56 @@
+import bcrypt from 'bcrypt';
+import { randomUUID } from 'crypto';
+import { Request, Response } from 'express';
+import { getRepository } from 'typeorm';
+import User, { UserRoleEnum } from '../../entity/UserEntity';
+import { makeSignUpToken } from '../../utils/auth';
+
+/**
+ * @swagger
+ * /user:
+ *  post:
+ *    tags:
+ *    - user
+ *    summary: 회원가입
+ *    description: 사용자가 최초에 회원가입을 요청할 시 사용되는 엔드포인트
+ *    parameters:
+ *    - in: body
+ *      name: body
+ *      description: 회원가입하는 사용자의 정보
+ *      required: true
+ *      schema:
+ *        type: object
+ *        properties:
+ *          email:
+ *            type: string
+ *            example: example@gmail.com
+ *            description: 사용자가 사용할 이메일
+ *          password:
+ *            type: string
+ *            example: abcd1212
+ *            description: 사용자가 사용할 비밀번호(프론트단에선 암호화할 필요x)
+ */
+export const saveUser = async (req: Request, res: Response) => {
+  try {
+    const id = randomUUID();
+    const { email, password } = req.body;
+    if (!email || !password)
+      throw new Error('no email or password in request body');
+    await getRepository(User)
+      .createQueryBuilder()
+      .insert()
+      .values({
+        id,
+        email,
+        password: bcrypt.hashSync(password, 10),
+        isLogout: false,
+        role: UserRoleEnum.GUEST,
+        token: makeSignUpToken(id),
+      })
+      .execute();
+    // TODO: 이메일 전송 로직 추가
+    res.status(201).json({ message: '회원가입 성공', id });
+  } catch (e) {
+    res.status(400).json({ message: '회원가입 실패: ' + (e as Error).message });
+  }
+};

--- a/src/services/User/index.ts
+++ b/src/services/User/index.ts
@@ -82,8 +82,7 @@ export const saveUser = async (req: Request, res: Response) => {
  */
 export const changeUserRole = async (req: Request, res: Response) => {
   const BAD_REQUEST = 'request is not valid';
-  const UNAUTHORIZED_ID = 'id not valid';
-  const UNAUTHORIZED_TOKEN = 'token is expired';
+  const UNAUTHORIZED = 'id not valid';
   const NOT_FOUND = 'no user with given id found';
   const OK = '사용자 권한 수정 성공';
 
@@ -95,8 +94,7 @@ export const changeUserRole = async (req: Request, res: Response) => {
       id: string;
       exp: number;
     };
-    if (decoded.id !== id) throw new Error(UNAUTHORIZED_ID);
-    if (decoded.exp * 1000 < Date.now()) throw new Error(UNAUTHORIZED_TOKEN);
+    if (decoded.id !== id) throw new Error(UNAUTHORIZED);
 
     const result = await getRepository(User)
       .createQueryBuilder()
@@ -117,10 +115,10 @@ export const changeUserRole = async (req: Request, res: Response) => {
       res
         .status(404)
         .json({ message: '회원가입 실패: ' + (e as Error).message });
-    } else if ((e as Error).message === UNAUTHORIZED_ID) {
+    } else if ((e as Error).message === UNAUTHORIZED) {
       res.status(403).json({ message: '회원가입 실패: ' + 'id 변조됨' });
-    } else if ((e as Error).message === UNAUTHORIZED_TOKEN) {
-      res.status(403).json({ message: '회원가입 실패: ' + UNAUTHORIZED_TOKEN });
+    } else if ((e as Error).message.includes('expire')) {
+      res.status(403).json({ message: '회원가입 실패: ' + '토큰 만료됨' });
     } else {
       res.status(400).json({ message: '회원가입 실패: ' + BAD_REQUEST });
     }

--- a/src/utils/auth/index.ts
+++ b/src/utils/auth/index.ts
@@ -1,0 +1,15 @@
+import jwt from 'jsonwebtoken';
+
+/**
+ * 회원가입시 사용될 토큰을 생성하는 함수
+ * 생성된 사용자 id를 받아 하루가 지나면 expire 하는 jwt를 생성
+ */
+export const makeSignUpToken = (id: string) => {
+  if (!process.env.SIGNUP_TOKEN_SECRET)
+    throw new Error('There is no secret key for signup token');
+
+  return jwt.sign({ id }, process.env.SIGNUP_TOKEN_SECRET, {
+    algorithm: 'HS256',
+    expiresIn: '1d', // 이메일 만료시간 1일
+  });
+};

--- a/test/User.test.ts
+++ b/test/User.test.ts
@@ -1,0 +1,62 @@
+import bcrypt from 'bcrypt';
+import request from 'supertest';
+import { Connection, ConnectionOptions, createConnection } from 'typeorm';
+import app from '../src';
+import { db } from '../src/config/db';
+import User, { UserRoleEnum } from '../src/entity/UserEntity';
+
+let conn: Connection;
+
+beforeAll(async () => {
+  conn = await createConnection({
+    ...db,
+    database: process.env.DB_DATABASE_TEST,
+  } as ConnectionOptions);
+});
+
+afterAll(() => {
+  conn.close();
+});
+
+describe('회원가입 api', () => {
+  test('email, password 정보를 포함한 회원가입 요청을 보낼 시 정상적으로 데이터베이스에 유저 정보가 생성된다', async () => {
+    // given
+    const email = 'example@test.com';
+    const password = 'testpassword';
+
+    // when
+    const res = await request(app).post('/api/user').send({ email, password });
+    const { message, id } = res.body;
+    const repo = conn.getRepository(User);
+    const user = await repo.findOne(id);
+
+    // then
+    expect(res.statusCode).toBe(201);
+    expect(message).toBeTruthy();
+    expect(id).toBeTruthy();
+
+    expect(user).toBeTruthy();
+    expect(user?.id).toEqual(id);
+    expect(user?.email).toEqual('example@test.com');
+    /* eslint-disable-next-line */
+    expect(bcrypt.compareSync('testpassword', user!.password)).toBeTruthy();
+    expect(user?.isLogout).toBe(false);
+    expect(user?.token).toBeTruthy();
+    expect(user?.role).toEqual(UserRoleEnum.GUEST);
+
+    await repo.delete({ id });
+  });
+
+  test('email 또는 password 정보를 body에 포함하지 않으면 코드 400으로 응답한다', async () => {
+    // given
+    const signupFailureLabel = '회원가입 실패';
+
+    // when
+    const res = await request(app).post('/api/user').send({});
+
+    // then
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toContain(signupFailureLabel);
+    expect(res.body.id).toBeFalsy();
+  });
+});

--- a/test/User.test.ts
+++ b/test/User.test.ts
@@ -14,7 +14,8 @@ beforeAll(async () => {
   } as ConnectionOptions);
 });
 
-afterAll(() => {
+afterAll(async () => {
+  await conn.getRepository(User).createQueryBuilder().delete().execute();
   conn.close();
 });
 
@@ -43,8 +44,6 @@ describe('회원가입 api', () => {
     expect(user?.isLogout).toBe(false);
     expect(user?.token).toBeTruthy();
     expect(user?.role).toEqual(UserRoleEnum.GUEST);
-
-    await repo.delete({ id });
   });
 
   test('email 또는 password 정보를 body에 포함하지 않으면 코드 400으로 응답한다', async () => {
@@ -58,5 +57,103 @@ describe('회원가입 api', () => {
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toContain(signupFailureLabel);
     expect(res.body.id).toBeFalsy();
+  });
+
+  test('이메일 링크를 클릭할 시 사용자 권한을 USER로 업데이트한다', async () => {
+    // given
+    const repo = conn.getRepository(User);
+    const user = await repo.findOne();
+
+    // when
+    const res = await request(app)
+      .patch(`/api/user/role/${user?.id}`)
+      .send({ token: user?.token });
+    const { message, id } = res.body;
+    const updatedUser = await repo.findOne({ id: user?.id });
+
+    // then
+    expect(res.statusCode).toBe(200);
+    expect(message).toBeTruthy();
+    expect(id).toEqual(user?.id);
+
+    expect(updatedUser).toBeTruthy();
+    expect(updatedUser?.id).toEqual(id);
+    expect(updatedUser?.email).toEqual(user?.email);
+    expect(updatedUser?.password).toEqual(user?.password);
+    expect(updatedUser?.isLogout).toEqual(user?.isLogout);
+    expect(updatedUser?.token).toEqual(user?.token);
+    expect(updatedUser?.role).toEqual(UserRoleEnum.USER);
+  });
+
+  test('이메일 링크를 클릭할 시 경로가 잘못되었을 경우 403 응답을 반환한다', async () => {
+    // given
+    const repo = conn.getRepository(User);
+    const user = await repo.findOne();
+    const invalidUserId = 'aaaaaa';
+    const invalidUserIdLabel = '회원가입 실패';
+
+    // when
+    const res = await request(app)
+      .patch(`/api/user/role/${invalidUserId}`)
+      .send({ token: user?.token });
+    const { message, id } = res.body;
+
+    // then
+    expect(res.statusCode).toBe(403);
+    expect(message).toContain(invalidUserIdLabel);
+    expect(id).toBeFalsy();
+  });
+
+  test('이메일 링크를 클릭할 시 토큰이 요청에 포함되지 않을 경우 400 응답을 반환한다', async () => {
+    // given
+    const repo = conn.getRepository(User);
+    const user = await repo.findOne();
+    const invalidToken = 'asdfasdf';
+    const invalidTokenLabel = '회원가입 실패';
+
+    // when
+    const res = await request(app)
+      .patch(`/api/user/role/${user?.id}`)
+      .send({ token: invalidToken });
+    const { message, id } = res.body;
+
+    // then
+    expect(res.statusCode).toBe(400);
+    expect(message).toContain(invalidTokenLabel);
+    expect(id).toBeFalsy();
+  });
+
+  test('이메일 클릭 시 이미 가입이 완료된 사용자에 대한 요청을 보낼 시 404 응답을 반환한다', async () => {
+    // given
+    const email = 'user@test.com';
+    const password = 'userpassword';
+    const invalidRequestLabel = '회원가입 실패';
+
+    const repo = conn.getRepository(User);
+    const userResult = await request(app)
+      .post('/api/user')
+      .send({ email, password });
+    const userId = userResult.body.id;
+    await repo
+      .createQueryBuilder()
+      .update()
+      .set({ role: UserRoleEnum.USER })
+      .where('id = :id', { id: userId })
+      .execute();
+    const user = await repo.findOne(userId);
+
+    // when
+    const res = await request(app)
+      .patch(`/api/user/role/${user?.id}`)
+      .send({ token: user?.token });
+    const { message, id } = res.body;
+
+    // then
+    expect(user?.role).toEqual(UserRoleEnum.USER);
+    expect(res.statusCode).toBe(404);
+    expect(message).toContain(invalidRequestLabel);
+    expect(id).toBeFalsy();
+
+    repo.delete({ id: userId });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -583,6 +583,21 @@
   resolved "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.8.tgz#32abc8a5c624bc4e46c43d84dfb8b26d33a96f58"
+  integrity sha512-CMGKi28CF+qlbXh26hDe6NxCd7amqeAzEqnS6IHeO6LoaKyM/n+Xw3HT1COdq8cuioOdlKdqn/hCmqPUOMOywg==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.5"
+    nopt "^5.0.0"
+    npmlog "^5.0.1"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.11"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -692,6 +707,13 @@
   integrity sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/bcrypt@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-5.0.0.tgz#a835afa2882d165aff5690893db314eaa98b9f20"
+  integrity sha512-agtcFKaruL8TmcvqbndlqHPSJgsolhf/qPWchFlgnW1gECTN/nKbFcoFnvKAQRFfKbh+BO6A3SWdJu9t+xF3Lw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/body-parser@*":
   version "1.19.1"
@@ -1092,7 +1114,7 @@ ansi-regex@^4.1.0:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.0:
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -1138,6 +1160,19 @@ app-root-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz"
   integrity sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw==
+
+"aproba@^1.0.3 || ^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
+  integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
+
+are-we-there-yet@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
+  integrity sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^3.6.0"
 
 arg@^4.1.0:
   version "4.1.3"
@@ -1253,6 +1288,14 @@ basic-auth@~2.0.1:
   integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
   dependencies:
     safe-buffer "5.1.2"
+
+bcrypt@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-5.0.1.tgz#f1a2c20f208e2ccdceea4433df0c8b2c54ecdf71"
+  integrity sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    node-addon-api "^3.1.0"
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -1461,6 +1504,11 @@ chokidar@^3.2.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz"
@@ -1548,6 +1596,11 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+color-support@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
@@ -1586,6 +1639,11 @@ configstore@^5.0.1:
     unique-string "^2.0.0"
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
+
+console-control-strings@^1.0.0, console-control-strings@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -1745,6 +1803,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
 denque@^1.4.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz"
@@ -1764,6 +1827,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -2249,6 +2317,13 @@ fresh@0.5.2:
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
@@ -2268,6 +2343,21 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+gauge@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
+  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
+  dependencies:
+    aproba "^1.0.3 || ^2.0.0"
+    color-support "^1.1.2"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.1"
+    object-assign "^4.1.1"
+    signal-exit "^3.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    wide-align "^1.1.2"
 
 generate-function@^2.3.1:
   version "2.3.1"
@@ -2424,6 +2514,11 @@ has-symbols@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-unicode@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 has-yarn@^2.1.0:
   version "2.1.0"
@@ -3443,7 +3538,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-make-dir@^3.0.0:
+make-dir@^3.0.0, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -3539,7 +3634,22 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mkdirp@^1.0.4:
+minipass@^3.0.0:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
+  integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -3620,6 +3730,18 @@ negotiator@0.6.2:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
+node-addon-api@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-fetch@^2.6.5:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
@@ -3656,6 +3778,13 @@ nodemon@^2.0.12:
     undefsafe "^2.0.3"
     update-notifier "^4.1.0"
 
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
+  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+  dependencies:
+    abbrev "1"
+
 nopt@~1.0.10:
   version "1.0.10"
   resolved "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
@@ -3680,12 +3809,22 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npmlog@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
+  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
+  dependencies:
+    are-we-there-yet "^2.0.0"
+    console-control-strings "^1.1.0"
+    gauge "^3.0.0"
+    set-blocking "^2.0.0"
+
 nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
-object-assign@^4, object-assign@^4.0.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -4206,6 +4345,11 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
 setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz"
@@ -4239,6 +4383,11 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
+
+signal-exit@^3.0.0:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
+  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
 signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.4"
@@ -4317,6 +4466,15 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz"
@@ -4362,6 +4520,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -4490,6 +4655,18 @@ table@^6.0.9:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
+tar@^6.1.11:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz"
@@ -4585,6 +4762,11 @@ tr46@^2.1.0:
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
   dependencies:
     punycode "^2.1.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
 ts-jest@^27.1.2:
   version "27.1.2"
@@ -4829,6 +5011,11 @@ walker@^1.0.7:
   dependencies:
     makeerror "1.0.x"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz"
@@ -4851,6 +5038,14 @@ whatwg-mimetype@^2.3.0:
   resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"
   resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz"
@@ -4866,6 +5061,13 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wide-align@^1.1.2:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
+  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
+  dependencies:
+    string-width "^1.0.2 || 2 || 3 || 4"
 
 widest-line@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
- 회원가입시 사용될 api controller 코드 및 테스트 코드를 추가했습니다
- .env 에 `DB_DATABASE_TEST` 와 `SIGNUP_TOKEN_SECRET`을 추가했습니다
- 개발할때 nodemon이 서버를 재시작시키는데 자꾸 테이블 에러가 나더라구요 그래서 일단 db 접속 설정에 synchronize 옵션 false로 바꿔뒀습니다
- 전에 npm 모듈 추가할때 말씀하셨던 bcrypt 모듈을 제가 설치안해뒀더라구요 이번 PR에서 추가했습니다
- swagger 문서를 jsdoc 으로 채워뒀는데 생각해보니 에러케이스 주석은 안써뒀네요.. 다음 PR에 추가하겠습니다