### PR TITLE
로그인 api 구현

### DIFF
--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+
+export const checkAccessToken = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  try {
+    const accessToken = req.cookies.accessToken;
+    if (!accessToken) throw new Error('먼저 로그인해야합니다');
+
+    const decoded = jwt.verify(
+      accessToken,
+      process.env.SIGNUP_TOKEN_SECRET!
+    ) as { id: string; email: string };
+    req.user = { id: decoded.id, email: decoded.email };
+
+    next();
+  } catch (e) {
+    res.status(403).json({ message: (e as Error).message });
+  }
+};

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction, Router } from 'express';
 import userIdRouter from './userid';
 import profileRouter from './profile';
+import loginRouter from './login';
 import { saveUser } from '../../services/User';
 
 const router = Router();
@@ -16,5 +17,6 @@ router.use(
   userIdRouter
 );
 router.use('/profile', profileRouter);
+router.use('/login', loginRouter);
 
 export default router;

--- a/src/routes/user/login/index.ts
+++ b/src/routes/user/login/index.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { login } from '../../../services/User';
+
+const router = Router();
+router.post('/', login);
+
+export default router;

--- a/src/services/User/index.ts
+++ b/src/services/User/index.ts
@@ -30,6 +30,23 @@ import jwt from 'jsonwebtoken';
  *            type: string
  *            example: abcd1212
  *            description: 사용자가 사용할 비밀번호(프론트단에선 암호화할 필요x)
+ *      responses:
+ *        "201":
+ *          description: "올바른 요청"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "회원가입 성공"
+ *        "400":
+ *          description: "요청 body에 이메일 또는 비밀번호 값이 없는 경우입니다"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "회원가입 실패: no email or password in request body"
  */
 export const saveUser = async (req: Request, res: Response) => {
   try {
@@ -58,7 +75,7 @@ export const saveUser = async (req: Request, res: Response) => {
 
 /**
  * @swagger
- * /user/role/:userid:
+ * /user/:userid/role:
  *  patch:
  *    tags:
  *    - user
@@ -67,7 +84,7 @@ export const saveUser = async (req: Request, res: Response) => {
  *    parameters:
  *    - in: path
  *      name: userid
- *      description: 회원가입하는 사용자의 id (요청 경로의 '-'를 허용해야하나?)
+ *      description: 회원가입하는 사용자의 id
  *      required: true
  *      example: 15f6d6ee-32e2-4036-b050-fa79e38dcd36
  *    - in: body
@@ -79,6 +96,41 @@ export const saveUser = async (req: Request, res: Response) => {
  *            type: string
  *            example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjUxYjg0M2I5LWE5ZTEtNDk3Mi05NWNiLWVmYTcxYzY2ODI5NSIsImlhdCI6MTY0MDYzMDg2MiwiZXhwIjoxNjQwNzE3MjYyfQ.zLJtNN-VCuYlghtE2v0yDJbz7YuxedGHKLt6CW7tUnA
  *            description: 사용자를 인증할 jwt토큰, email의 링크에 쿼리스트링으로 보내줄 예정
+ *      responses:
+ *        "200":
+ *          description: "올바른 요청"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "사용자 권한 수정 성공"
+ *        "400":
+ *          description: "아래 두 에러가 아닌 다른 이유의 에러입니다. 코드 실행중 에러가 발생한 상황입니다"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "회원가입 실패: request is not valid"
+ *        "403":
+ *          description: "전달한 토큰값에 저장된 사용자 id와 url 경로상의 id가 일치하지 않거나, 토큰이 만료된 경우입니다"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example:
+ *                - "회원가입 실패: id 변조됨"
+ *                - "회원가입 실패 :토큰 만료됨"
+ *        "404":
+ *          description: "전달된 userid값이 데이터베이스에 없는 경우입니다"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "회원가입 실패: no user with given id found"
  */
 export const changeUserRole = async (req: Request, res: Response) => {
   const BAD_REQUEST = 'request is not valid';

--- a/src/services/User/index.ts
+++ b/src/services/User/index.ts
@@ -128,12 +128,60 @@ export const changeUserRole = async (req: Request, res: Response) => {
 };
 
 export const login = async (req: Request, res: Response) => {
+  const BAD_REQUEST = '이메일/비밀번호 정보 없음';
+  const UNAUTHORIZED = '비밀번호 불일치';
+  const NOT_FOUND = '일치하는 이메일 없음';
+
   try {
     const { email, password } = req.body;
-    res.cookie('accessToken', email, { httpOnly: true });
-    res.cookie('refreshToken', password, { httpOnly: true });
-    res.json({ message: 'ok' });
+    if (!email || !password) throw new Error(BAD_REQUEST);
+
+    const user = await getRepository(User)
+      .createQueryBuilder()
+      .select()
+      .where('email = :email', { email })
+      .getOne();
+    if (!user) throw new Error(NOT_FOUND);
+
+    const isUser = bcrypt.compareSync(password, user?.password);
+    if (!isUser) throw new Error(UNAUTHORIZED);
+
+    const accessToken = jwt.sign(
+      { id: user.id, email: user.email },
+      process.env.SIGNUP_TOKEN_SECRET!,
+      {
+        algorithm: 'HS256',
+        expiresIn: '3h',
+      }
+    );
+    const refreshToken = jwt.sign(
+      { id: user.id, email: user.email },
+      process.env.SIGNUP_TOKEN_SECRET!,
+      {
+        algorithm: 'HS256',
+        expiresIn: '14d',
+      }
+    );
+
+    const hour = 3600 * 1000;
+    const day = 24 * hour;
+    res.cookie('accessToken', accessToken, {
+      httpOnly: true,
+      expires: new Date(Date.now() + 3 * hour),
+    });
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      expires: new Date(Date.now() + 14 * day),
+    });
+
+    res.json({ message: '로그인 성공' });
   } catch (e) {
-    res.status(400).json({ message: (e as Error).message });
+    const err = e as Error;
+    if (err.message === UNAUTHORIZED) {
+      res.status(403).json({ message: '로그인 싪패: ' + UNAUTHORIZED });
+    } else if (err.message === NOT_FOUND) {
+      res.status(404).json({ message: '로그인 싪패: ' + NOT_FOUND });
+    }
+    res.status(400).json({ message: err.message });
   }
 };

--- a/src/services/User/index.ts
+++ b/src/services/User/index.ts
@@ -127,6 +127,54 @@ export const changeUserRole = async (req: Request, res: Response) => {
   }
 };
 
+/**
+ *  @swagger
+ *  /user/login:
+ *    post:
+ *      tags:
+ *      - user
+ *      summary: "로그인"
+ *      description: "로그인하기 위한 엔드포인트입니다. 로그인 성공시 사용자의 쿠키에 액세스토큰, 리프레시 토큰을 발급합니다"
+ *      parameters:
+ *      - in: "body"
+ *        name: "body"
+ *        description: "사용자 로그인 정보"
+ *        required: true
+ *        schema:
+ *          type: object
+ *          properties:
+ *            email:
+ *              type: string
+ *              example: "test@example.com"
+ *            password:
+ *              type: string
+ *              example: "examplepassword"
+ *      responses:
+ *        "200":
+ *          description: "올바른 요청"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "로그인 성공"
+ *        "403":
+ *          description: "전달한 비밀번호와 데이터베이스에 저장된 비밀번호가 일치하지 않습니다"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "로그인 실패: 비밀번호 불일치"
+ *        "404":
+ *          description: "전달한 이메일이 데이터베이스에 없는 경우입니다"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "로그인 실패: 일치하는 이메일 없음"
+ */
 export const login = async (req: Request, res: Response) => {
   const BAD_REQUEST = '이메일/비밀번호 정보 없음';
   const UNAUTHORIZED = '비밀번호 불일치';

--- a/src/services/User/index.ts
+++ b/src/services/User/index.ts
@@ -126,3 +126,14 @@ export const changeUserRole = async (req: Request, res: Response) => {
     }
   }
 };
+
+export const login = async (req: Request, res: Response) => {
+  try {
+    const { email, password } = req.body;
+    res.cookie('accessToken', email, { httpOnly: true });
+    res.cookie('refreshToken', password, { httpOnly: true });
+    res.json({ message: 'ok' });
+  } catch (e) {
+    res.status(400).json({ message: (e as Error).message });
+  }
+};

--- a/src/utils/cookie/index.ts
+++ b/src/utils/cookie/index.ts
@@ -1,0 +1,12 @@
+/**
+ *
+ * @param cookies 쿠키 하나에 대한 정보를 가지는 문자열
+ * @returns 쿠키에 대한 정보를 가지는 객체 하나, name 프로퍼티에 쿠키의 이름,
+ *   values 프로퍼티에 쿠키의 값이 저장되고 flags 프로퍼티에 배열의 형태로 기타 정보가 저장됨
+ */
+export const parseCookie = (cookies: string) => {
+  const values = cookies.split('; ');
+  const [name, value] = values[0].split('=');
+  const flags = values.slice(1).map((str) => str.split('='));
+  return { name, value, flags };
+};

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from 'crypto';
+import request from 'supertest';
+import {
+  Connection,
+  ConnectionOptions,
+  createConnection,
+  getRepository,
+} from 'typeorm';
+import User, { UserRoleEnum } from '../src/entity/UserEntity';
+import app from '../src';
+import { db } from '../src/config/db';
+import bcrypt from 'bcrypt';
+import { parseCookie } from '../src/utils/cookie';
+
+let conn: Connection;
+
+beforeAll(async () => {
+  conn = await createConnection({
+    ...db,
+    database: process.env.DB_DATABASE_TEST,
+  } as ConnectionOptions);
+
+  const password = bcrypt.hashSync('test', 10);
+
+  await getRepository(User)
+    .createQueryBuilder()
+    .insert()
+    .values({
+      id: randomUUID(),
+      email: 'test@example.com',
+      password: password,
+      isLogout: false,
+      token: '',
+      role: UserRoleEnum.USER,
+    })
+    .execute();
+});
+
+afterAll(async () => {
+  await conn.getRepository(User).createQueryBuilder().delete().execute();
+  conn.close();
+});
+
+describe('로그인 api', () => {
+  test('/api/user/login에 요청을 전송할 시 쿠키에 액세스 토큰과 리프레시 토큰을 발급한다', async () => {
+    // given
+    const email = 'test@example.com';
+    const password = 'test';
+
+    // when
+    const res = await request(app)
+      .post('/api/user/login')
+      .send({ email, password });
+    const cookies = res.headers['set-cookie'].map((cookie: string) =>
+      parseCookie(cookie)
+    );
+    const accessToken = cookies.find(
+      (cookie: { name: string }) => cookie.name === 'accessToken'
+    );
+    const refreshToken = cookies.find(
+      (cookie: { name: string }) => cookie.name === 'refreshToken'
+    );
+
+    // then
+    expect(accessToken).not.toBe(-1);
+    expect(refreshToken).not.toBe(-1);
+  });
+});

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -93,4 +93,30 @@ describe('로그인 api', () => {
     expect(decoded.id).toBe(userId);
     expect(decoded.email).toBe(email);
   });
+
+  test('리프레시 토큰에도 유저의 id와 email값이 저장된다', async () => {
+    // given
+    const email = 'test@example.com';
+    const password = 'test';
+    const res = await request(app)
+      .post('/api/user/login')
+      .send({ email, password });
+    const cookies = res.headers['set-cookie'].map((cookie: string) =>
+      parseCookie(cookie)
+    );
+    const token = cookies.find(
+      (cookie: { name: string; value: string }) =>
+        cookie.name === 'refreshToken'
+    ).value;
+
+    // when
+    const decoded = jwt.verify(token, process.env.SIGNUP_TOKEN_SECRET!) as {
+      id: string;
+      email: string;
+    };
+
+    // then
+    expect(decoded.id).toBe(userId);
+    expect(decoded.email).toBe(email);
+  });
 });


### PR DESCRIPTION
- 로그인 api를 구현했습니다. 이렇게 하는게 맞는건지 잘 모르겠네요..
- 우선 이메일과 비밀번호를 POST 요청에 실어보내면 서버에서 액세스토큰과 리프레시토큰을 만들어 요청을 보낸 사용자의 브라우저의 쿠키에 저장합니다
- 두 토큰 모두 로그인 요청을 보낸 사용자의 id와 이메일을 저장하도록 해뒀는데, 이게 맞는건지 잘 모르겠네요
- 리프레시토큰을 데이터베이스에 저장할 생각이었는데, 이렇게하면 조금 느려질수도 있겠다는 생각이 들었어요. 액세스토큰이 만료될때마다 데이터베이스를 찾아서 쿠키의 리프레시토큰과 비교해야되니까..
- 이후 요청을 보낼때 사용자가 로그인했는지의 여부를 요청에 포함된 토큰을 기준으로 판단하기 위해 req.user에 값을 할당해주는 미들웨어를 써 두긴 했는데, 이 부분도 제대로 한건지 잘 모르겠네요
- 인증 영역은 처음 다뤄봐서 헤매느라 오래 걸렸는데, 결과물이 처참하네요.. 궁금한 점 있으시면 여쭤봐 주시고 간단하게 피드백 부탁드리겠습니다!