### PR TITLE
스터디 목록 조회 API

### DIFF
--- a/src/entity/StudyEntity.ts
+++ b/src/entity/StudyEntity.ts
@@ -12,7 +12,7 @@ import {
 import User from './UserEntity';
 import Category from './CategoryEntity';
 
-enum WeekDayEnum {
+export enum WeekDayEnum {
   MON = '월',
   TUE = '화',
   WED = '수',
@@ -21,12 +21,12 @@ enum WeekDayEnum {
   SAT = '토',
   SUN = '일',
 }
-enum FrequencyEnum {
+export enum FrequencyEnum {
   ONCE = '1회',
   TWICE = '주 2-4회',
   MORE = '주 5회 이상',
 }
-enum LocationEnum {
+export enum LocationEnum {
   NO_CONTACT = '비대면',
   ROOM = '학교 스터디룸',
   LIBRARY = '중앙도서관',

--- a/src/routes/study/index.ts
+++ b/src/routes/study/index.ts
@@ -1,14 +1,14 @@
 import { Router } from 'express';
-import helloWorld from '../hello-world';
 import studyIdRouter from './studyid';
 import commentRouter from './comment';
 import detailRouter from './detail';
 import userRouter from './user';
-import { registerStudy } from '../../services/study';
+import { getAllStudy, createStudy } from '../../services/study';
 
 const router = Router();
-router.get('/', helloWorld);
-router.post('/', registerStudy);
+router.get('/', getAllStudy);
+router.post('/', createStudy);
+
 router.use('/:studyid', studyIdRouter);
 router.use('/comment', commentRouter);
 router.use('/detail', detailRouter);

--- a/src/services/study/index.ts
+++ b/src/services/study/index.ts
@@ -168,7 +168,7 @@ export const createStudy = async (req: Request, res: Response) => {
 
     res.status(201).json({ message: 'Created. 새로운 스터디 생성됨.' });
     // 스터디 상세 화면으로 이동하도록 추가
-    res.redirect('/api/study/detail/:studyId');
+    res.redirect('/api/study/detail/:id');
   } catch (e) {
     res.json({ error: (e as Error).message || (e as Error).toString() });
   }

--- a/src/services/study/index.ts
+++ b/src/services/study/index.ts
@@ -1,11 +1,95 @@
 import { Request, Response } from 'express';
 import { getRepository } from 'typeorm';
 import { randomUUID } from 'crypto';
-import Study from '../../entity/StudyEntity';
+import Study, {
+  WeekDayEnum,
+  FrequencyEnum,
+  LocationEnum,
+} from '../../entity/StudyEntity';
+import Category from '../../entity/CategoryEntity';
 import User from '../../entity/UserEntity';
-interface Body extends Partial<Study> {
-  userRepo: Partial<User>;
-}
+
+/**
+ * @swagger
+ * paths:
+ *  /study:
+ *    get:
+ *      summary: "스터디 목록 조회"
+ *      tags:
+ *      - "study"
+ *      description: "메인페이지에서 모든 스터디의 목록을 조회하기 위한 엔드포인트"
+ *      parameters:
+ *      - name: "row_num"
+ *        in: "query"
+ *        description: "한 페이지에 포함할 항목의 갯수, 기본값: 12"
+ *        required: false
+ *        type: integer
+ *      - name: "page_num"
+ *        in: "query"
+ *        description: "페이지 번호, 기본값: 1"
+ *        required: false
+ *        type: integer
+ *      - name: "frequency"
+ *        in: "query"
+ *        description: "필터 조건 - 스터디 빈도 / FrequencyEnum"
+ *        required: false
+ *        type: string
+ *      - name: "weekday"
+ *        in: "query"
+ *        description: "필터 조건 - 요일 / WeekDayEnum"
+ *        required: false
+ *        type: string
+ *      - name: "location"
+ *        in: "query"
+ *        description: "필터 조건 - 장소 / LocationEnum"
+ *        required: false
+ *        type: string
+ *      - name: "order_by"
+ *        in: "query"
+ *        description: "정렬 조건 기본값: 최근 등록순 (enum: latest, small_vacancy, large_vacancy)"
+ *        required: false
+ *        type: string
+ */
+
+export const getAllStudy = async (req: Request, res: Response) => {
+  const row_num = Number(req.query.row_num) || 12; // 한 페이지에서 포함할 스터디의 개수
+  const page_num = Number(req.query.page_num) || 1; // 현재 페이지 번호
+  const frequencyFilter = req.query.frequency || null; // enum
+  const weekdayFilter = req.query.weekday || null; // enum
+  const locationFilter = req.query.location || null; // enum
+  const order_by = req.query.order_by || 'latest'; // enum
+
+  try {
+    const studyRepo = getRepository(Study);
+    const skip = (page_num - 1) * row_num; // 각 페이지마다 스킵해야 할 스터디의 개수
+    const studyQuery = await studyRepo
+      .createQueryBuilder('study')
+      .where('study.frequency = :frequencyFilter', { frequencyFilter })
+      .andWhere('study.weekday = :weekdayFilter', { weekdayFilter })
+      .andWhere('study.location = :locationFilter', { locationFilter });
+
+    if (order_by === 'latest') studyQuery.orderBy('study.createdAt', 'DESC');
+    else if (order_by === 'small_vacancy')
+      studyQuery.orderBy('study.vacancy', 'ASC');
+    else if (order_by === 'large_vacancy')
+      studyQuery.orderBy('study.vacancy', 'DESC');
+
+    const [total_studies, total_count] = await studyQuery.getManyAndCount(); // total_count: 현재 등록된 스터디의 총 개수
+    const lastPage_count = total_count % row_num; // 마지막 페이지에 나타날 스터디의 개수
+    const total_page =
+      lastPage_count === 0
+        ? total_count / row_num
+        : Math.trunc(total_count / row_num) + 1; // 총 페이지의 개수
+    const perPage_studies = await total_studies.slice(skip, skip + row_num); // 각 페이지별 스터디의 개수
+
+    res.status(200).json({ message: 'OK. 스터디 목록 조회 성공.' });
+    return res.json({ perPage_studies, total_page }); // 각 페이지별 스터디 목록, 페이지 총 개수
+  } catch (e) {
+    res.status(404).json({
+      message: (e as Error).message + '. 요청한 리소스가 존재하지 않음',
+    });
+  }
+};
 
 /**
  * @swagger
@@ -25,9 +109,18 @@ interface Body extends Partial<Study> {
  *          $ref: "#/definitions/Study"
  */
 
-export const registerStudy = async (req: Request, res: Response) => {
+export const createStudy = async (req: Request, res: Response) => {
   try {
     const id = randomUUID();
+    type RequestBody = {
+      title: string;
+      studyAbout: string;
+      weekday: WeekDayEnum;
+      frequency: FrequencyEnum;
+      location: LocationEnum;
+      capacity: number;
+      categoryCode: Category;
+    };
     const {
       title,
       studyAbout,
@@ -35,40 +128,47 @@ export const registerStudy = async (req: Request, res: Response) => {
       frequency,
       location,
       capacity,
-      hostId,
       categoryCode,
-    } = req.body as Body;
+    }: RequestBody = req.body;
 
-    // categoryCode, hostId 불러올 방법 수정
-    const userRepo = getRepository(User);
-    const user = await userRepo.findOne(hostId);
-    if (user?.isLogout == false) {
+    // hostId => redis 수정
+    const userId = req.cookies.userId;
+    const hostId = await getRepository(User)
+      .createQueryBuilder('user')
+      .where('user.id = :userId', { userId })
+      .getOne();
+    if (!hostId) {
+      res.status(403).json({ error: 'Forbidden. 접근 권한 없음.' });
+      return;
+    }
+
+    if (hostId.isLogout === true) {
       res.status(401).json({ error: 'Unauthorized. 로그인 필요.' });
       return;
     }
 
-    await getRepository(Study)
-      .createQueryBuilder()
-      .insert()
-      .values({
-        id,
-        createdAt: Date.now(),
-        title,
-        studyAbout,
-        weekday,
-        frequency,
-        location,
-        capacity,
-        membersCount: 0,
-        vacancy: capacity,
-        isOpen: true,
-        views: 0,
-        hostId,
-        categoryCode,
-      })
-      .execute();
+    const studyRepo = getRepository(Study);
+    const study = new Study();
+    study.id = id;
+    study.createdAt = new Date();
+    study.title = title;
+    study.studyAbout = studyAbout;
+    study.weekday = weekday;
+    study.frequency = frequency;
+    study.location = location;
+    study.capacity = capacity;
+    study.membersCount = 0;
+    study.vacancy = capacity;
+    study.isOpen = true;
+    study.hostId = hostId!;
+    study.views = 0;
+    study.categoryCode = categoryCode;
+
+    await studyRepo.save(study);
 
     res.status(201).json({ message: 'Created. 새로운 스터디 생성됨.' });
+    // 스터디 상세 화면으로 이동하도록 추가
+    res.redirect('/api/study/detail/:studyId');
   } catch (e) {
     res.json({ error: (e as Error).message || (e as Error).toString() });
   }


### PR DESCRIPTION
일단 페이징이랑 필터 반영해서 스터디 목록 조회하도록 했는데, 제대로 잘 한 건지 모르겠네요
나름대로 페이징해보기는 했는데, 혹시 수정할 부분이 있는지 가볍게 봐주시면 감사하겠습니다!
필터링 관련해서는 필터들이 전부 기본값이 세팅되어야 할 것 같아서 frequency, weekday, location 필터들이 query로 들어오지 않았을 경우에는 null 값을 줬는데, 사실 이 상황에서 필터에 null 값을 주는 게 맞는지 조금 애매하더라고요. 이 부분에 대해서도 간단하게 봐주시면 감사하겠습니다

스터디 등록 관련해서는 redis 사용해서 hostId 불러오려고 했는데, 아직 연결이 제대로 되지 않은 것 같아서 오늘 다시 한 번 시도해보려고 합니다. 그래서 아직 redis 반영해서 짠 코드는 push 하지 않은 상태고요! 이번 주 내로 다시 확인해서 올리겠습니다
현재는 redis 시도하기 전 코드로 push 한 거라 일단 userId를 쿠키에서 받아오는 식으로 했습니다. 생성된 후에 해당 스터디의 상세 페이지로 가는 게 맞는 것 같아서 해당 path로 리다이렉트 되도록 했습니다.

몇 일 전에 했을 때는 test랑 dev 둘 다 잘 돌아갔는데, 또 다시 하니까 db에러가 뜨더라고요..? 아직 해결하고 있어서 해당 부분 해결하고 코드 전부 다 잘 돌아가는지 확인한 다음에 이번 주 내에 redis 반영한 코드 push 할 때 같이 올리겠습니다!