### PR TITLE
Update access token httpOnly option

### DIFF
--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -28,8 +28,10 @@ export const refresh = async (req: Request, res: Response) => {
     const newAccessToken = generateToken({ id: decoded.id });
 
     res.cookie('accessToken', newAccessToken, {
-      httpOnly: true,
       expires: new Date(Date.now() + 1000 * 60 * 60 * 3),
+      domain: 'cau.rudy3091.com',
+      sameSite: 'none',
+      secure: true,
     });
   } catch (e) {
     res.status(403).json({ message: (e as Error).message });

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -27,8 +27,9 @@ export const refresh = async (req: Request, res: Response) => {
 
     const newAccessToken = generateToken({ id: decoded.id });
 
+    const hour = 3600 * 1000;
     res.cookie('accessToken', newAccessToken, {
-      expires: new Date(Date.now() + 1000 * 60 * 60 * 3),
+      expires: new Date(Date.now() + 3 * hour),
       domain: 'cau.rudy3091.com',
       sameSite: 'none',
       secure: true,

--- a/src/routes/user/login/login.controller.ts
+++ b/src/routes/user/login/login.controller.ts
@@ -39,7 +39,6 @@ export default {
       const hour = 3600 * 1000;
       const day = 24 * hour;
       res.cookie('accessToken', accessToken, {
-        httpOnly: true,
         expires: new Date(Date.now() + 3 * hour),
         domain: 'cau.rudy3091.com',
         sameSite: 'none',


### PR DESCRIPTION
프론트에서 로그인 여부를 판단하기 위해 access token에 접근할 수 있었으면 좋겠다는 요청이 있었습니다
로그인 시에 생성하는 access token과 access token이 만료되고 refresh token만 남아서 새로운 access token을 발급해줄 때 httpOnly 옵션을 제거함으로서 클라이언트에서 해당 쿠키에 접근할 수 있도록 했습니다