### PR TITLE
이메일 전송 로직 추가

### DIFF
--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import { sendMail } from '../../services/mail';
 import { deleteUserById, saveUser, updateUserById } from '../../services/user';
 import { makeSignUpToken } from '../../utils/auth';
+import { validateCAU } from '../../utils/mail';
 
 export default {
   async saveUser(req: Request, res: Response) {
@@ -11,6 +12,9 @@ export default {
       const { email, password } = req.body;
       if (!email || !password)
         throw new Error('no email or password in request body');
+      const isValidEmail = validateCAU(email);
+      if (!isValidEmail)
+        throw new Error('중앙대 이메일로만 가입할 수 있습니다');
 
       const token = makeSignUpToken(id);
       // TODO: await의 나열보다 Promise.all 의 사용이 성능적인 이점이 있을까?

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
 import { sendMail } from '../../services/mail';
 import { deleteUserById, saveUser, updateUserById } from '../../services/user';
+import { makeSignUpToken } from '../../utils/auth';
 
 export default {
   async saveUser(req: Request, res: Response) {
@@ -11,8 +12,11 @@ export default {
       if (!email || !password)
         throw new Error('no email or password in request body');
 
-      await saveUser({ id, email, password });
-      const message = await sendMail(email);
+      const token = makeSignUpToken(id);
+      // TODO: await의 나열보다 Promise.all 의 사용이 성능적인 이점이 있을까?
+      await saveUser({ id, email, password, token });
+      const message = await sendMail(email, id, token);
+
       res.status(201).json({ message, id });
     } catch (e) {
       res

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
+import { sendMail } from '../../services/mail';
 import { deleteUserById, saveUser, updateUserById } from '../../services/user';
 
 export default {
@@ -11,8 +12,8 @@ export default {
         throw new Error('no email or password in request body');
 
       await saveUser({ id, email, password });
-      // TODO: 이메일 전송 로직 추가
-      res.status(201).json({ message: '회원가입 성공', id });
+      const message = await sendMail(email);
+      res.status(201).json({ message, id });
     } catch (e) {
       res
         .status(400)
@@ -84,7 +85,7 @@ export default {
  *            properties:
  *              message:
  *                type: string
- *                example: "회원가입 성공"
+ *                example: "메일을 전송했습니다. 메일함을 확인해주세요"
  *        "400":
  *          description: "요청 body에 이메일 또는 비밀번호 값이 없는 경우입니다"
  *          schema:

--- a/src/services/mail/html.ts
+++ b/src/services/mail/html.ts
@@ -1,3 +1,102 @@
-export const html = () => `<body>
-  <h1>caulipse 회원가입</h1>
-</body>`;
+const _createElement = ({
+  tagName,
+  className,
+  styles,
+  children,
+  attr,
+}: {
+  tagName: string;
+  className: string;
+  styles: [string, string][];
+  children?: string[];
+  attr?: [string, string][];
+}) => `
+<${tagName}
+  class="${className}"
+  style="${styles.map(([key, value]) => `${key}: ${value};`).join('')}"
+  ${attr?.map(([key, value]) => `${key}=${value} `).join('')}
+>
+  ${children?.join('')}
+</${tagName}>`;
+
+const _greeting = () =>
+  _createElement({
+    tagName: 'div',
+    className: 'greeting',
+    styles: [
+      ['font-size', '18px'],
+      ['font-weight', '900'],
+    ],
+    children: ['<h2>~~님 환영합니다!</h2>'],
+  });
+
+const _instruction = () =>
+  _createElement({
+    tagName: 'div',
+    className: 'instruction',
+    styles: [
+      ['margin', '8px 0 64px 0'],
+      ['font-size', '16px'],
+    ],
+    children: ['<span>인증 버튼을 눌러 회원가입을 완료하세요</span>'],
+  });
+
+const _button = () =>
+  _createElement({
+    tagName: 'button',
+    className: 'button',
+    styles: [
+      ['border', 'none'],
+      ['border-radius', '8px'],
+      ['background-color', '#7393ff'],
+      ['padding', '12px 18px'],
+      ['font-size', '16px'],
+      ['font-weight', '700'],
+      ['color', '#fff'],
+      ['cursor', 'pointer'],
+    ],
+    children: ['<span>중앙대 인증</span>'],
+    attr: [['role', 'button']],
+  });
+
+const _link = (id: string, token: string) =>
+  _createElement({
+    tagName: 'a',
+    className: 'button',
+    styles: [['text-decoration', 'none']],
+    children: [_button()],
+    attr: [
+      [
+        'href',
+        `https://github.com/caulipse/caulipse-server?id=${id}&token=${token}`,
+      ], // TODO: 우리 서비스 주소로 리다이렉트
+      ['target', '_blank'],
+    ],
+  });
+
+const _container = (id: string, token: string) =>
+  _createElement({
+    tagName: 'div',
+    className: 'container',
+    styles: [
+      ['max-width', '500px'],
+      ['margin', '0 auto'],
+      ['padding', '32px'],
+      ['background-color', '#f8f8f8'],
+      ['text-align', 'center'],
+      ['border-radius', '8px'],
+    ],
+    children: [_greeting(), _instruction(), _link(id, token)],
+  });
+
+export const html = (id: string, token: string) =>
+  _createElement({
+    tagName: 'div',
+    className: 'body',
+    styles: [
+      ['width', '100%'],
+      ['padding', '0'],
+      ['margin', '0'],
+    ],
+    children: [_container(id, token)],
+  });

--- a/src/services/mail/html.ts
+++ b/src/services/mail/html.ts
@@ -1,0 +1,3 @@
+export const html = () => `<body>
+  <h1>caulipse 회원가입</h1>
+</body>`;

--- a/src/services/mail/index.ts
+++ b/src/services/mail/index.ts
@@ -4,9 +4,15 @@ import { html } from './html';
 /**
  *
  * @param dest 메일을 수신할 상대 이메일 주소
+ * @param id 메일인증을 진행할 사용자의 id
+ * @param token 메일인증을 위해 발급받은 토큰값
  * @returns 메일 전송과정에서 에러 발생시 Error 객체, 성공시 메일 전송 성공을 알리는 문자열을 가진 Promise 객체 반환
  */
-export const sendMail = async (dest: string): Promise<string> => {
+export const sendMail = async (
+  dest: string,
+  id: string,
+  token: string
+): Promise<string> => {
   const transporter = nodemailer.createTransport({
     host: 'smtp.gmail.com',
     secure: false,
@@ -20,7 +26,7 @@ export const sendMail = async (dest: string): Promise<string> => {
     from: process.env.MAIL_USER,
     to: dest,
     subject: '회원가입을 완료해주세요',
-    html: html(),
+    html: html(id, token),
   };
 
   return new Promise((resolve, reject) => {

--- a/src/services/mail/index.ts
+++ b/src/services/mail/index.ts
@@ -1,0 +1,32 @@
+import nodemailer from 'nodemailer';
+import { html } from './html';
+
+/**
+ *
+ * @param dest 메일을 수신할 상대 이메일 주소
+ * @returns 메일 전송과정에서 에러 발생시 Error 객체, 성공시 메일 전송 성공을 알리는 문자열을 가진 Promise 객체 반환
+ */
+export const sendMail = async (dest: string): Promise<string> => {
+  const transporter = nodemailer.createTransport({
+    host: 'smtp.gmail.com',
+    secure: false,
+    auth: {
+      user: process.env.MAIL_USER,
+      pass: process.env.MAIL_PASSWORD,
+    },
+  });
+
+  const option = {
+    from: process.env.MAIL_USER,
+    to: dest,
+    subject: '회원가입을 완료해주세요',
+    html: html(),
+  };
+
+  return new Promise((resolve, reject) => {
+    transporter.sendMail(option, (err) => {
+      if (err) reject(err);
+      else resolve('메일을 전송했습니다. 메일함을 확인해주세요');
+    });
+  });
+};

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -1,15 +1,15 @@
 import bcrypt from 'bcrypt';
 import { getRepository } from 'typeorm';
 import User, { UserRoleEnum } from '../../entity/UserEntity';
-import { makeSignUpToken } from '../../utils/auth';
 
 interface SaveUserDTO {
   id: string;
   email: string;
   password: string;
+  token: string;
 }
 
-export const saveUser = async ({ id, email, password }: SaveUserDTO) => {
+export const saveUser = async ({ id, email, password, token }: SaveUserDTO) => {
   return await getRepository(User)
     .createQueryBuilder()
     .insert()
@@ -19,7 +19,7 @@ export const saveUser = async ({ id, email, password }: SaveUserDTO) => {
       password: bcrypt.hashSync(password, 10),
       isLogout: false,
       role: UserRoleEnum.GUEST,
-      token: makeSignUpToken(id),
+      token,
     })
     .execute();
 };

--- a/src/utils/mail/index.ts
+++ b/src/utils/mail/index.ts
@@ -1,0 +1,5 @@
+export const validateCAU = (email: string): boolean => {
+  const [, latter] = email.split('@');
+  if (latter !== 'cau.ac.kr') return false;
+  return true;
+};

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -24,7 +24,7 @@ afterAll(async () => {
 describe('회원가입 api', () => {
   test('email, password 정보를 포함한 회원가입 요청을 보낼 시 정상적으로 데이터베이스에 유저 정보가 생성된다', async () => {
     // given
-    const email = 'example@test.com';
+    const email = 'example@cau.ac.kr';
     const password = 'testpassword';
 
     // when
@@ -40,7 +40,7 @@ describe('회원가입 api', () => {
 
     expect(user).toBeTruthy();
     expect(user?.id).toEqual(id);
-    expect(user?.email).toEqual('example@test.com');
+    expect(user?.email).toEqual('example@cau.ac.kr');
     /* eslint-disable-next-line */
     expect(bcrypt.compareSync('testpassword', user!.password)).toBeTruthy();
     expect(user?.isLogout).toBe(false);


### PR DESCRIPTION
- 회원가입 시 데이터베이스에 사용자의 이메일과 패스워드를 저장할 때 입력받은 이메일 검증 및 인증 메일을 전송하는 로직을 추가했습니다
- PR 머지 이후 .env 파일에
  ```
  MAIL_USER=
  MAIL_PASSWORD=
  ```
  를 추가해야 동작하는데, 우리 caulipse 구글 계정에 메일 관련 설정을 하지 않은 상태라 아마 에러가 발생할 것 같습니다.
  이부분은 좀 더 조사 후 설정한 뒤 테스트해볼 예정입니다
- 메일의 본문이 될 html 템플릿은 초기 문서에 썼던 디자인 그대로 가져왔습니다
- 인증메일의 링크를 클릭했을 때 이동시킬 주소가 아직 정해지지 않아 `<a></a>` 태그에 href 속성을 임시로 작성해뒀습니다