### PR TITLE
fix: 유저 정보 get api에서 로그아웃 필드 삭제

### DIFF
--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -80,7 +80,6 @@ export default {
           data: {
             id: result.id,
             email: result.email,
-            isLogout: result.isLogout,
             role: result.role,
           },
         });


### PR DESCRIPTION
- 프론트에서 at 여부를 통해 로그인 여부를 판별하고 있습니다.
- 서버에서 내려주는 값과 중복이 되어 사용하지 않는 것이 좋을 것 같아 엔드포인트에서 로그아웃 여부를 삭제했습니다.