### PR TITLE
fix: bookmark api에서 categoryCode 삭제

### DIFF
--- a/src/services/study/bookmark/index.ts
+++ b/src/services/study/bookmark/index.ts
@@ -22,7 +22,6 @@ const getBookmarksByUser = async (id: string) => {
   return await getRepository(Study)
     .createQueryBuilder('study')
     .leftJoin('study.bookmarks', 'user')
-    .leftJoinAndSelect('study.categoryCode', 'category')
     .where('user.id = :id', { id })
     .orderBy('study.createdAt', 'DESC')
     .getMany();


### PR DESCRIPTION
- bookmark 리스트 get하는 api에서 아래와 같은 에러가 발생해 join 문에서 category 관련 코드를 삭제해 해결했습니다.

![image](https://user-images.githubusercontent.com/59302192/158216024-b79cd678-9a77-49ac-b02a-a15221bf3b4d.png)
