### PR TITLE
Feature/pagination page number

### DIFF
--- a/src/routes/notice/notice.controller.ts
+++ b/src/routes/notice/notice.controller.ts
@@ -187,9 +187,15 @@ export default {
  *        200:
  *          description: "올바른 요청"
  *          schema:
- *            type: array
- *            items:
- *              $ref: "#/definitions/Notice"
+ *            type: object
+ *            properties:
+ *              pages:
+ *                type: number
+ *                description: "총 페이지의 갯수를 의미하는 숫자값입니다"
+ *              data:
+ *                type: array
+ *                items:
+ *                  $ref: "#/definitions/Notice"
  *    post:
  *      summary: "새로운 공지사항 생성"
  *      description: "ADMIN 권한을 가진 사용자가 공지사항을 생성할 때 사용되는 엔드포인트입니다"

--- a/src/routes/notice/notice.controller.ts
+++ b/src/routes/notice/notice.controller.ts
@@ -6,6 +6,7 @@ import {
   findAllNotice,
   findAllUser,
   findNoticeById,
+  findNoticeCount,
   updateNoticeById,
   updateNoticeViews,
 } from '../../services/notice';
@@ -18,6 +19,8 @@ export default {
       const limit = req.query.amount || 12;
       const offset = req.query.offset || 0; // FIXME: cursor 디폴트값 설정
 
+      const totalNoticeCount = await findNoticeCount();
+      const totalPageCount = Math.floor(totalNoticeCount / +limit) + 1;
       const result = await findAllNotice({
         amount: +limit,
         offset: +offset,
@@ -30,7 +33,10 @@ export default {
         views: item.Notice_VIEWS,
         hostId: item.Notice_HOST_ID,
       }));
-      res.json(response);
+      res.json({
+        pages: totalPageCount,
+        data: response,
+      });
     } catch (e) {
       res.status(500).json({ message: '오류 발생' });
     }

--- a/src/services/notice/index.ts
+++ b/src/services/notice/index.ts
@@ -7,6 +7,10 @@ export const findAllUser = async () => {
   return await getRepository(User).createQueryBuilder().select('id').getMany();
 };
 
+export const findNoticeCount = async () => {
+  return await getRepository(Notice).createQueryBuilder().select().getCount();
+};
+
 export const findAllNotice = async ({
   amount,
   offset,

--- a/test/notice.test.ts
+++ b/test/notice.test.ts
@@ -120,6 +120,39 @@ describe('공지사항 페이지네이션', () => {
     // then
     expect(res.body.data.length).toBe(12);
   });
+
+  test('5개씩 요청했을 때 총 페이지 갯수 응답은 7이다', async () => {
+    // given
+    const amount = 5;
+
+    // when
+    const res = await request(app).get(`/api/notice?amount=${amount}`);
+
+    // then
+    expect(res.body.pages).toBe(7);
+  });
+
+  test('9개씩 요청했을 때 총 페이지 갯수 응답은 4이다', async () => {
+    // given
+    const amount = 9;
+
+    // when
+    const res = await request(app).get(`/api/notice?amount=${amount}`);
+
+    // then
+    expect(res.body.pages).toBe(4);
+  });
+
+  test('100개씩 요청했을 때 총 페이지 갯수 응답은 1이다', async () => {
+    // given
+    const amount = 100;
+
+    // when
+    const res = await request(app).get(`/api/notice?amount=${amount}`);
+
+    // then
+    expect(res.body.pages).toBe(1);
+  });
 });
 
 describe('공지사항 업데이트 api', () => {

--- a/test/notice.test.ts
+++ b/test/notice.test.ts
@@ -65,7 +65,7 @@ describe('공지사항 조회 api', () => {
   test('데이터를 조회한다', async () => {
     const res = await request(app).get('/api/notice');
     expect(res.statusCode).toBe(200);
-    expect(res.body.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.data.length).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -109,7 +109,7 @@ describe('공지사항 페이지네이션', () => {
     const res = await request(app).get(`/api/notice?amount=${amount}`);
 
     // then
-    expect(res.body.length).toBe(5);
+    expect(res.body.data.length).toBe(5);
   });
 
   test('쿼리스트링 정보를 아무것도 주지 않으면 12개의 항목을 반환한다', async () => {
@@ -118,7 +118,7 @@ describe('공지사항 페이지네이션', () => {
     const res = await request(app).get('/api/notice');
 
     // then
-    expect(res.body.length).toBe(12);
+    expect(res.body.data.length).toBe(12);
   });
 });
 


### PR DESCRIPTION
공지사항 목록 조회 api의 응답에 총 페이지 갯수를 포함합니다
기존 배열 형태의 응답 데이터는 응답 객체의 data 프로퍼티로 할당했고, 페이지 갯수를 의미하는 숫자 데이터는 pages 라는 이름으로 할당해줬습니다
해당 내용은 스웨거 문서에도 반영했습니다
또 이전에 체크를 못했나본데 notice service 에 유저 조회를 위한 로직이 작성돼있는데 찾아보니 notice controller 에서 사용중이더라구요
해당 로직은 user service 로 옮기면 좋을 것 같습니다!