### PR TITLE
Update swagger docs for study list api

### DIFF
--- a/src/entity/StudyEntity.ts
+++ b/src/entity/StudyEntity.ts
@@ -149,8 +149,7 @@ export default class Study {
  *        - "기타"
  *        description: "스터디 장소"
  *      hostId:
- *        type: string
- *        format: uuid
+ *        $ref: "#/definitions/User"
  *        description: "스터디 host의 id"
  *      capacity:
  *        type: integer
@@ -165,7 +164,7 @@ export default class Study {
  *        type: boolean
  *        description: "모집중 여부"
  *      categoryCode:
- *        $ref: "#/definitions/Category"
+ *        type: integer
  *        description: "스터디의 카테고리 코드"
  *      views:
  *        type: integer

--- a/src/routes/study/study.controller.ts
+++ b/src/routes/study/study.controller.ts
@@ -318,10 +318,21 @@ export default {
  *        200:
  *          description: "올바른 요청. 스터디 객체 배열, 현재 페이지, 전체 페이지 수, 전체 스터디 개수를 반환합니다."
  *          schema:
- *            allOf:
- *            - type: array
- *              items:
- *                $ref: "#/definitions/Study"
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "스터디 목록 조회 성공"
+ *              studies:
+ *                type: array
+ *                items:
+ *                  $ref: "#/definitions/Study"
+ *              pageNo:
+ *                type: integer
+ *              pages:
+ *                type: integer
+ *              total:
+ *                type: integer
  *
  *    post:
  *      summary: "새로운 스터디 생성"


### PR DESCRIPTION
스터디 리스트 조회 api에 대한 스웨거 문서를 수정했습니다
응답이 오는 구조에 맞게 수정했는데, 각 프로퍼티들이 정확히 무슨 역할을 하는지 몰라서 적지 못했습니다
이부분 추가해주시면 감사하겠습니다
추가로 응답 객체의 studies 프로퍼티는 실제 데이터에 해당하는 스터디 목록인데, 현재 HOST_ID 프로퍼티에 스터디 개설 사용자의 id가 오고 있는데 거기에 더해서 hostId 라는 프로퍼티로 해당 유저의 정보들이 join돼서 조회되고 있습니다 이부분도 통일해주시면 좋을 것 같습니다!