### PR TITLE
북마크 카운트 로직 및 모집 스터디 api 추가

### DIFF
--- a/src/entity/StudyEntity.ts
+++ b/src/entity/StudyEntity.ts
@@ -83,6 +83,9 @@ export default class Study {
   @Column('int', { name: 'VIEWS' })
   views!: number;
 
+  @Column('int', { name: 'BOOKMARK_COUNT' })
+  bookmarkCount!: number;
+
   @ManyToMany(() => User, { cascade: true })
   @JoinTable({
     name: 'BOOKMARK',
@@ -170,6 +173,9 @@ export default class Study {
  *      views:
  *        type: integer
  *        description: "현재 스터디 조회수"
+ *      bookmarkCount:
+ *        type: integer
+ *        description: "현재 스터디에 등록된 북마크 개수"
  *
  *  Bookmark:
  *    type: object

--- a/src/routes/notice/notice.controller.ts
+++ b/src/routes/notice/notice.controller.ts
@@ -90,7 +90,7 @@ export default {
       if ((e as Error).message === BAD_REQUEST) {
         return res.status(400).json({ message: BAD_REQUEST });
       } else if ((e as Error).message === FORBIDDEN) {
-        return res.status(404).json({ message: FORBIDDEN });
+        return res.status(403).json({ message: FORBIDDEN });
       } else if ((e as Error).message === NOT_FOUND) {
         return res.status(404).json({ message: NOT_FOUND });
       } else {
@@ -249,14 +249,14 @@ export default {
  *                type: string
  *                example: "일치하는 userid가 없음"
  *
- *  /api/notice/{noticeid}:
+ *  /api/notice/{notiid}:
  *    get:
  *      summary: "공지사항 아이디에 해당하는 공지사항 상제 정보 조회"
  *      description: "공지사항 상세페이지에서 각 공지사항 아이디에 해당하는 모든 상세 정보들을 조회할 엔드포인트입니다"
  *      tags:
  *      - "notice"
  *      parameters:
- *      - name: "noticeid"
+ *      - name: "notiid"
  *        in: "path"
  *        description: "정보를 조회할 공지사항 id"
  *        required: true
@@ -264,7 +264,7 @@ export default {
  *        format: uuid
  *      responses:
  *        200:
- *          description: "올바른 요청, message와 함께 스터디 정보를 반환합니다"
+ *          description: "올바른 요청, 스터디 정보를 반환합니다"
  *          schema:
  *            $ref: "#/definitions/Notice"
  *        404:
@@ -286,7 +286,7 @@ export default {
  *      produces:
  *      - "application/json"
  *      parameters:
- *      - name: "noticeid"
+ *      - name: "notiid"
  *        in: "path"
  *        description: "수정할 공지사항 id"
  *        required: true
@@ -354,7 +354,7 @@ export default {
  *      tags:
  *      - "notice"
  *      parameters:
- *      - name: "noticeid"
+ *      - name: "notiid"
  *        in: "path"
  *        description: "삭제할 공지사항 id"
  *        required: true

--- a/src/routes/study/index.ts
+++ b/src/routes/study/index.ts
@@ -16,6 +16,9 @@ router.delete('/:studyid', checkToken, controller.deleteStudy);
 
 router.get('/search', controller.searchStudy);
 
+// 모집 스터디 라우터
+router.get('/my-study', checkToken, controller.getMyStudy);
+
 // 스터디 참가 신청 라우터
 router.use('/user/:studyid', checkToken, studyUserRouter);
 // 스터디 북마크 라우터

--- a/src/routes/study/study.controller.ts
+++ b/src/routes/study/study.controller.ts
@@ -58,6 +58,17 @@ const getAllStudy = async (req: Request, res: Response) => {
   }
 };
 
+const getMyStudy = async (req: Request, res: Response) => {
+  try {
+    const userId = (req.user as { id: string }).id;
+
+    const studies = await studyService.getMyStudy(userId);
+    return res.status(200).json({ message: '모집스터디 조회 성공', studies });
+  } catch (e) {
+    return res.status(500).json({ message: (e as Error).message });
+  }
+};
+
 const createStudy = async (req: Request, res: Response) => {
   const BAD_REQUEST = '요청값이 유효하지 않음';
   const NOT_FOUND = '데이터베이스에 일치하는 요청값이 없습니다';
@@ -262,6 +273,7 @@ const searchStudy = async (req: Request, res: Response) => {
 
 export default {
   getAllStudy,
+  getMyStudy,
   createStudy,
   getStudybyId,
   updateStudy,
@@ -598,4 +610,28 @@ export default {
  *            - type: array
  *              items:
  *                $ref: "#/definitions/Study"
+ *
+ *  /api/study/my-study:
+ *    get:
+ *      summary: "스터디 검색 목록 조회"
+ *      tags:
+ *      - "study"
+ *      - "my-page"
+ *      description: "사용자가 검색한 스터디의 목록을 조회할 수 있습니다"
+ *      responses:
+ *        200:
+ *          description: "올바른 요청."
+ *          schema:
+ *            allOf:
+ *            - type: array
+ *              items:
+ *                $ref: "#/definitions/Study"
+ *        401:
+ *          description: "로그인이 되어있지 않은 경우"
+ *          schema:
+ *            type: object
+ *            properties:
+ *              message:
+ *                type: string
+ *                example: "로그인 필요"
  */

--- a/src/routes/study/study.controller.ts
+++ b/src/routes/study/study.controller.ts
@@ -10,7 +10,7 @@ const getAllStudy = async (req: Request, res: Response) => {
   const frequencyFilter: string = req.query.frequency as string;
   const weekdayFilter: string = req.query.weekday as string;
   const locationFilter: string = req.query.location as string;
-  const orderBy: string = req.query.order_by as string | orderByEnum.LATEST;
+  const orderBy: string = (req.query.order_by as string) || orderByEnum.LATEST;
   // offset
   const pageNo = Number(req.query.pageNo) || 1;
   const limit = Number(req.query.limit) || 12;
@@ -38,7 +38,7 @@ const getAllStudy = async (req: Request, res: Response) => {
     const pages =
       lastpage === 0 ? total / limit : Math.trunc(total / limit) + 1;
 
-    if (!studies) {
+    if (studies.length === 0) {
       return res
         .status(200)
         .json({ message: '요청에 해당하는 스터디가 존재하지 않습니다' });
@@ -232,7 +232,7 @@ const searchStudy = async (req: Request, res: Response) => {
   const frequencyFilter: string = req.query.frequency as string;
   const weekdayFilter: string = req.query.weekday as string;
   const locationFilter: string = req.query.location as string;
-  const orderBy: string = req.query.order_by as string | orderByEnum.LATEST;
+  const orderBy: string = (req.query.order_by as string) || orderByEnum.LATEST;
 
   try {
     const studies = await studyService.searchStudy(
@@ -243,7 +243,7 @@ const searchStudy = async (req: Request, res: Response) => {
       orderBy
     );
 
-    if (!studies) {
+    if (studies.length === 0) {
       return res
         .status(200)
         .json({ message: '요청에 해당하는 스터디가 존재하지 않습니다' });

--- a/src/services/study/bookmark/index.ts
+++ b/src/services/study/bookmark/index.ts
@@ -12,7 +12,8 @@ const findBookmarksByStudyId = async (id: string) => {
 const registerBookmark = async (bookmarks: Study[], user: User) => {
   bookmarks.forEach((bookmark) => {
     bookmark.bookmarks.push(user);
-    // console.log(bookmark.bookmarks);
+
+    bookmark.bookmarkCount += 1;
   });
 
   await getRepository(Study).save(bookmarks);
@@ -28,7 +29,11 @@ const getBookmarksByUser = async (id: string) => {
 };
 
 const deleteBookmark = async (study: Study, user: User) => {
-  return await getRepository(Study)
+  const repo = getRepository(Study);
+  study.bookmarkCount -= 1;
+  await repo.save(study);
+
+  return await repo
     .createQueryBuilder('study')
     .relation('bookmarks')
     .of(study)

--- a/src/services/study/index.ts
+++ b/src/services/study/index.ts
@@ -108,6 +108,7 @@ const createStudy = async (studyDTO: studyDTO, user: User) => {
   study.hostId = user;
   study.views = 0;
   study.categoryCode = categoryCode;
+  study.bookmarkCount = 0;
 
   await getRepository(Study).save(study);
   return studyId;

--- a/src/services/study/index.ts
+++ b/src/services/study/index.ts
@@ -68,6 +68,14 @@ const getAllStudy = async (paginationDTO: paginationDTO) => {
   return await sq.limit(limit).offset(offset).getMany();
 };
 
+const getMyStudy = async (userId: string) => {
+  return await getRepository(Study)
+    .createQueryBuilder('study')
+    .leftJoinAndSelect('study.hostId', 'user')
+    .where('study.HOST_ID = :userId', { userId })
+    .getMany();
+};
+
 const findStudyById = async (id: string) => {
   return await getRepository(Study)
     .createQueryBuilder('study')
@@ -193,6 +201,7 @@ const searchStudy = async (
 export default {
   countAllStudy,
   getAllStudy,
+  getMyStudy,
   findStudyById,
   updateStudyViews,
   createStudy,

--- a/src/services/study/index.ts
+++ b/src/services/study/index.ts
@@ -73,6 +73,7 @@ const getMyStudy = async (userId: string) => {
     .createQueryBuilder('study')
     .leftJoinAndSelect('study.hostId', 'user')
     .where('study.HOST_ID = :userId', { userId })
+    .orderBy('study.createdAt', 'ASC')
     .getMany();
 };
 
@@ -81,6 +82,7 @@ const findStudyById = async (id: string) => {
     .createQueryBuilder('study')
     .leftJoinAndSelect('study.hostId', 'user')
     .where('study.id = :id', { id })
+    .orderBy('study.createdAt', 'ASC')
     .getOne();
 };
 

--- a/test/study.test.ts
+++ b/test/study.test.ts
@@ -108,9 +108,9 @@ describe('GET /api/study', () => {
   it('query를 포함한 요청을 받으면 필터링, 정렬, 페이지네이션을 거친 후 스터디 목록과 페이지 커서 반환(첫번째 페이지)', async () => {
     const res = await request(app).get('/api/study').query({
       categoryCode: 101,
-      frequencyFilter: FrequencyEnum.TWICE,
-      weekdayFilter: WeekDayEnum.MON,
-      locationFilter: LocationEnum.CAFE,
+      frequency: FrequencyEnum.TWICE,
+      weekday: WeekDayEnum.MON,
+      location: LocationEnum.CAFE,
     });
     const { studies, next_cursor } = res.body;
 


### PR DESCRIPTION
- 해당 PR에서 작업한 파트
   - 북마크 개수 카운트 로직 추가
   - 모집 스터디 조회 API
<br>

- 먼저, 북마크 개수는 추가할 필요가 있다고 하셔서 study entity에 추가하고 관련 로직들도 추가했습니다. 제가 생각난 부분들을 전부 작업해 놓기는 했는데, 북마크 개수 관련해서 더 추가해야 할 부분들이 있다면 말씀해 주세요.
- 모집 스터디 API는 알림 페이지처럼 마감된 스터디가 구분되어서 보여지더라고요. 저번에 해당 페이지들 같은 경우는 페이지네이션 없이 전달하는 게 편하다고 하셨던 것 같아서 따로 페이지네이션 없이 작업했고 오래된 순으로 정렬되도록 했습니다.
- 마이페이지 관련 라우터들이 분리되어 있지 않아서 제 임의대로 모집 스터디 엔드포인트를 스터디 라우터에 추가했습니다. 혹시 마이페이지 관련 라우터를 따로 분리하거나 해당 url을 변경할 필요가 있을 것 같다고 생각되면 말씀해 주시면 반영하겠습니다.