### PR TITLE
스터디 참가신청 사용자 조회 관련기능 추가

### DIFF
--- a/src/routes/study/index.ts
+++ b/src/routes/study/index.ts
@@ -20,7 +20,7 @@ router.patch('/:studyid', checkToken, controller.updateStudy);
 router.delete('/:studyid', checkToken, controller.deleteStudy);
 
 // 스터디 참가 신청 라우터
-router.use('/user/:studyid', checkToken, studyUserRouter);
+router.use('/user/:studyid', studyUserRouter);
 // 스터디 북마크 라우터
 router.use('/:studyid/bookmark', checkToken, bookmarkRouter);
 // 스터디 문의글 라우터

--- a/src/routes/study/studyUser/index.ts
+++ b/src/routes/study/studyUser/index.ts
@@ -1,13 +1,15 @@
 import { Router } from 'express';
+import { checkToken } from '../../../middlewares/auth';
 import controller from './studyUser.controller';
 
 const router = Router({ mergeParams: true });
 
-router.get('/', controller.getStudyUserList);
-router.post('/', controller.joinStudy);
-router.patch('/', controller.updateStudyJoin);
-router.delete('/', controller.deleteStudyJoin);
+router.get('/', checkToken, controller.getStudyUserList);
+router.post('/', checkToken, controller.joinStudy);
+router.patch('/', checkToken, controller.updateStudyJoin);
+router.delete('/', checkToken, controller.deleteStudyJoin);
 
-router.patch('/accept', controller.acceptUser);
+router.get('/participants', controller.getStudyParticipants);
+router.patch('/accept', checkToken, controller.acceptUser);
 
 export default router;

--- a/src/routes/study/studyUser/studyUser.controller.ts
+++ b/src/routes/study/studyUser/studyUser.controller.ts
@@ -100,7 +100,6 @@ export default {
       } else if ((e as Error).message === NOT_FOUND) {
         res.status(404).json({ message: NOT_FOUND });
       } else {
-        console.log((e as Error).message);
         res.status(500).json({ message: 'error' });
       }
     }

--- a/src/routes/study/studyUser/studyUser.controller.ts
+++ b/src/routes/study/studyUser/studyUser.controller.ts
@@ -230,8 +230,8 @@ export default {
  *     get:
  *       tags:
  *       - study/user
- *       summary: "현재 참가 신청중인 사용자 목록을 읽어옵니다."
- *       description: "해당 스터디에 참가 신청중인 사용자 목록을 읽어오기 위한 엔드포인트입니다."
+ *       summary: "현재 참가신청 수락대기중인 인원의 목록을 조회합니다"
+ *       description: "해당 스터디에 참가신청이 수락대기 상태인 사용자 목록을 읽어오기 위한 엔드포인트입니다. 해당 스터디의 호스트만 조회할 수 있습니다."
  *       produces:
  *       - "application/json"
  *       parameters:
@@ -431,6 +431,38 @@ export default {
  *               message:
  *                 type: string
  *                 example: "일치하는 studyid가 없음"
+ *
+ * /api/study/user/{studyid}/participants:
+ *   get:
+ *     tags:
+ *     - study/user
+ *     summary: "해당 스터디에 참여중인 사용자 목록을 조회합니다"
+ *     description: "해당 스터디에 참여중인(참가신청이 수락된) 사용자 목록을 조회하기 위한 엔드포인트입니다. 로그인하지 않아도 정상적인 데이터를 응답합니다"
+ *     parameters:
+ *     - in: "path"
+ *       name: "studyid"
+ *       description: "참여자 목록을 조회할 스터디 id"
+ *       required: true
+ *       type: string
+ *       format: uuid
+ *
+ *     responses:
+ *       200:
+ *         description: "올바른 요청"
+ *         schema:
+ *           allOf:
+ *           - type: array
+ *             items:
+ *               type: object
+ *               $ref: "#/definitions/StudyUser"
+ *       404:
+ *         description: "전달한 studyid가 데이터베이스에 없는 경우입니다"
+ *         schema:
+ *           type: object
+ *           properties:
+ *             message:
+ *               type: string
+ *               example: "일치하는 studyid가 없음"
  *
  * /api/study/user/{studyid}/accept:
  *   patch:

--- a/src/services/studyUser/index.ts
+++ b/src/services/studyUser/index.ts
@@ -73,7 +73,7 @@ export const findNotAcceptedApplicantsByStudyId = async (studyId: string) => {
     .createQueryBuilder()
     .select()
     .where('STUDY_ID = :id', { id: studyId })
-    .andWhere('ACCEPTED = 0')
+    .andWhere('IS_ACCEPTED = 0')
     .execute();
 };
 

--- a/src/services/studyUser/index.ts
+++ b/src/services/studyUser/index.ts
@@ -53,12 +53,27 @@ export const findAllIfParticipatedByUserId = async (userId: string) => {
     );
 };
 
+/**
+ * 참가신청이 수락된 사용자 목록 조회(참여자 조회)
+ */
 export const findAcceptedByStudyId = async (studyId: string) => {
   return await getRepository(StudyUser)
     .createQueryBuilder()
     .select()
     .where('STUDY_ID = :id', { id: studyId })
     .andWhere('IS_ACCEPTED = 1')
+    .execute();
+};
+
+/**
+ * 참가신청이 수락대기중인 사용자 목록 조회
+ */
+export const findNotAcceptedApplicantsByStudyId = async (studyId: string) => {
+  return await getRepository(StudyUser)
+    .createQueryBuilder()
+    .select()
+    .where('STUDY_ID = :id', { id: studyId })
+    .andWhere('ACCEPTED = 0')
     .execute();
 };
 

--- a/test/studyUser.test.ts
+++ b/test/studyUser.test.ts
@@ -64,6 +64,7 @@ beforeAll(async () => {
   mockStudy.vacancy = 10;
   mockStudy.isOpen = true;
   mockStudy.views = 0;
+  mockStudy.bookmarkCount = 0;
 
   await conn.getRepository(Study).save(mockStudy);
 });
@@ -229,7 +230,7 @@ describe('참가신청 api', () => {
   });
 });
 
-describe('참가 신청중인 사용자 목록 조회 api', () => {
+describe('참가신청 수락대기중인 사용자 목록 조회 api', () => {
   const email = 'qwernm@test.com';
   const password = 'testpassword';
   const userId = randomUUID();
@@ -261,7 +262,7 @@ describe('참가 신청중인 사용자 목록 조회 api', () => {
     expect(res.statusCode).toBe(404);
   });
 
-  test('자신이 소유하지 않은 스터디에 대한 신청자 현황을 요청하면 참가가 수락된 인원만 반환한다', async () => {
+  test('자신이 소유하지 않은 스터디에 대한 참가신청 수락대기중 인원 현황을 요청하면 403 코드로 응답한다', async () => {
     // given
     const loginRes = await request(app)
       .post('/api/user/login')
@@ -274,11 +275,10 @@ describe('참가 신청중인 사용자 목록 조회 api', () => {
       .set('Cookie', cookies);
 
     // then
-    expect(res.statusCode).toBe(200);
-    expect(res.body.length).toBe(0);
+    expect(res.statusCode).toBe(403);
   });
 
-  test('자신이 소유한 스터디에 대한 신청자 현황을 요청하면 200 코드로 응답한다', async () => {
+  test('자신이 소유한 스터디에 대한 참가신청 수락대기 현황을 요청하면 200 코드로 응답한다', async () => {
     // given
     const newUserEmail = 'asodfjaod@test.com';
     const newUserPassword = 'testPassword';
@@ -310,6 +310,7 @@ describe('참가 신청중인 사용자 목록 조회 api', () => {
         vacancy: 10,
         isOpen: true,
         views: 0,
+        bookmarkCount: 0,
       })
       .execute();
 


### PR DESCRIPTION
- 스터디 참여가 수락된 인원에 대한 정보를 조회하기 위한 api를 추가했습니다
- 기존의 스터디 참여인원 api는 참가신청 수락대기중인 사용자들을 응답하도록 수정했습니다

- `/api/study/user/:studyid`
  - 스터디 참가 수락대기중 인원 조회
  - 인증 필요 (개설자가 아니면 조회불가)
- `/api/study/user/:studyid/participants`
  - 스터디 참여가 수락된 인원 조회
  - 인증 필요 X