### PR TITLE
Fix notice api pagination query variable's name (#73)

### DIFF
--- a/src/routes/notice/notice.controller.ts
+++ b/src/routes/notice/notice.controller.ts
@@ -16,7 +16,7 @@ import { createNoticeNoti } from '../../services/notification';
 export default {
   async findAllNotice(req: Request, res: Response) {
     try {
-      const limit = req.query.amount || 12;
+      const limit = req.query.limit || 12;
       const offset = req.query.offset || 0; // FIXME: cursor 디폴트값 설정
 
       const totalNoticeCount = await findNoticeCount();


### PR DESCRIPTION
페이지네이션을 위한 변수이름 limit이 올바르지 않던 문제 해결