### PR TITLE
내가 신청한 스터디 리스트 조회 api 데이터 추가 (#72)

### DIFF
--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -104,6 +104,9 @@ export default {
         createdAt: item.CREATED_AT,
         views: item.VIEWS,
         bookmarkCount: item.BOOKMARK_COUNT,
+        isAccepted: !!item.IS_ACCEPTED,
+        membersCount: item.MEMBERS_COUNT,
+        capacity: item.CAPACITY,
       }));
       res.json(response);
     } catch (e) {

--- a/src/services/studyUser/index.ts
+++ b/src/services/studyUser/index.ts
@@ -44,10 +44,15 @@ export const findAllIfParticipatedByUserId = async (userId: string) => {
   return await getConnection()
     .createQueryRunner()
     .query(
-      'SELECT STUDY.ID, STUDY.TITLE, STUDY.CREATED_AT, STUDY.VIEWS, STUDY.BOOKMARK_COUNT FROM STUDY \
-        JOIN STUDY_USER ON \
+      'SELECT \
+        STUDY.ID, STUDY.TITLE, STUDY.CREATED_AT, STUDY.VIEWS, \
+        STUDY.BOOKMARK_COUNT, STUDY.CAPACITY, STUDY.MEMBERS_COUNT, STUDY_USER.IS_ACCEPTED \
+      FROM STUDY \
+      JOIN \
+        STUDY_USER ON \
         STUDY_USER.STUDY_ID = STUDY.ID \
-        WHERE STUDY_USER.USER_ID = ? \
+      WHERE \
+        STUDY_USER.USER_ID = ?\
         ORDER BY STUDY.CREATED_AT',
       [userId]
     );

--- a/test/mystudy.test.ts
+++ b/test/mystudy.test.ts
@@ -59,7 +59,7 @@ beforeAll(async () => {
   mockStudy.capacity = 10;
   mockStudy.hostId = mockHost;
   mockStudy.categoryCode = 100;
-  mockStudy.membersCount = 10;
+  mockStudy.membersCount = 1;
   mockStudy.vacancy = 10;
   mockStudy.isOpen = true;
   mockStudy.views = 0;
@@ -130,7 +130,7 @@ describe('내가 신청한 스터디 조회 api', () => {
     expect(res.body).toEqual([]);
   });
 
-  test('신청한 스터디가 있을 경우 해당 스터디의 제목, 생성날짜, 조회수, 북마크수를 응답한다', async () => {
+  test('신청한 스터디가 있을 경우 해당 스터디의 제목, 생성날짜, 조회수, 북마크수, 수락여부, 스터디의 참석자 수, 정원 수를 응답한다', async () => {
     // given
     const cookies = user2cookie;
     await conn
@@ -155,9 +155,14 @@ describe('내가 신청한 스터디 조회 api', () => {
     // then
     expect(res.statusCode).toBe(200);
     expect(res.body.length).toBe(1);
-    expect(res.body[0]).toHaveProperty('title');
-    expect(res.body[0]).toHaveProperty('createdAt');
-    expect(res.body[0]).toHaveProperty('views');
-    expect(res.body[0]).toHaveProperty('bookmarkCount');
+    expect(res.body[0]?.title).toEqual(mockStudy.title);
+    expect(new Date(res.body[0]?.createdAt).toString()).toEqual(
+      new Date(mockStudy.createdAt).toString()
+    );
+    expect(res.body[0]?.views).toEqual(mockStudy.views);
+    expect(res.body[0]?.bookmarkCount).toEqual(mockStudy.bookmarkCount);
+    expect(res.body[0]?.isAccepted).toEqual(false);
+    expect(res.body[0]?.membersCount).toEqual(mockStudy.membersCount);
+    expect(res.body[0]?.capacity).toEqual(mockStudy.capacity);
   });
 });


### PR DESCRIPTION
내가 신청한 스터디 리스트 조회시 해당 참가신청의 수락여부, 스터디의 현재 참가 인원수, 정원 인원수 정보를 함께 반환하도록 수정