### PR TITLE
fix: notice 생성

### DIFF
--- a/src/routes/notice/notice.controller.ts
+++ b/src/routes/notice/notice.controller.ts
@@ -87,12 +87,14 @@ export default {
 
       const noticeId = await createNotice(title, about, user);
 
-      const users = await findAllUser();
-      if (users.length !== 0) {
-        const notiTitle = '새로운 공지';
-        const notiAbout = '새 공지사항이 등록되었어요';
-        for (const u of users) {
-          await createNoticeNoti(noticeId, u?.id, notiTitle, notiAbout, 201);
+      if (process.env.NODE_ENV !== 'test') {
+        const users = await findAllUser();
+        if (users.length !== 0) {
+          const notiTitle = '새로운 공지';
+          const notiAbout = '중대본으로부터 새로운 공지글이 등록되었어요.';
+          for (const u of users) {
+            await createNoticeNoti(noticeId, u?.id, notiTitle, notiAbout, 201);
+          }
         }
       }
 

--- a/src/routes/study/comment/comment.controller.ts
+++ b/src/routes/study/comment/comment.controller.ts
@@ -63,14 +63,28 @@ const createComment = async (req: Request, res: Response) => {
       reply
     );
 
-    if (reply && reply.USER_ID) {
-      const notiTitle = '답글';
-      const notiAbout = '작성하신 문의글에 답글이 달렸어요';
-      await createStudyNoti(studyid, reply.USER_ID, notiTitle, notiAbout, 104);
-    } else {
-      const notiTitle = '새로운 문의글';
-      const notiAbout = '새 문의글이 달렸어요';
-      await createStudyNoti(studyid, study.HOST_ID, notiTitle, notiAbout, 102);
+    if (process.env.NODE_ENV !== 'test') {
+      if (reply && reply.USER_ID) {
+        const notiTitle = '답글';
+        const notiAbout = '작성하신 문의글에 답글이 달렸어요.';
+        await createStudyNoti(
+          studyid,
+          reply.USER_ID,
+          notiTitle,
+          notiAbout,
+          104
+        );
+      } else {
+        const notiTitle = '새로운 문의글';
+        const notiAbout = '새 문의글이 달렸어요.';
+        await createStudyNoti(
+          studyid,
+          study.HOST_ID,
+          notiTitle,
+          notiAbout,
+          102
+        );
+      }
     }
 
     return res.status(201).json({

--- a/src/routes/study/study.controller.ts
+++ b/src/routes/study/study.controller.ts
@@ -166,7 +166,7 @@ const updateStudy = async (req: Request, res: Response) => {
 
   try {
     const { studyid } = req.params;
-  
+
     if (!Object.keys(req.body).length) throw new Error(BAD_REQUEST);
     const allowedFields = [
       'title',
@@ -188,18 +188,20 @@ const updateStudy = async (req: Request, res: Response) => {
     }
     await studyService.updateStudy(req.body, study);
 
-    const users = await findAllByStudyId(studyid);
-    if (users.length !== 0) {
-      const notiTitle = '모집정보 수정';
-      const notiAbout = '신청한 스터디의 모집 정보가 수정되었어요';
-      for (const user of users) {
-        await createStudyNoti(
-          studyid,
-          user?.user?.id,
-          notiTitle,
-          notiAbout,
-          103
-        );
+    if (process.env.NODE_ENV !== 'test') {
+      const users = await findAllByStudyId(studyid);
+      if (users.length !== 0) {
+        const notiTitle = '모집정보 수정';
+        const notiAbout = '신청한 스터디의 모집 정보가 수정되었어요.';
+        for (const user of users) {
+          await createStudyNoti(
+            studyid,
+            user?.USER_ID,
+            notiTitle,
+            notiAbout,
+            103
+          );
+        }
       }
     }
 

--- a/src/routes/study/studyUser/studyUser.controller.ts
+++ b/src/routes/study/studyUser/studyUser.controller.ts
@@ -107,7 +107,7 @@ export default {
       if (process.env.NODE_ENV !== 'test') {
         const profile = await findUserProfileById(userId);
         const notiTitle = '새로운 신청자';
-        const notiAbout = `[${profile?.userName}]님이 신청 수락을 기다리고 있어요!`;
+        const notiAbout = `[${profile?.userName}]님이 신청수락을 요청했어요.`;
         await createStudyNoti(
           studyid,
           study.HOST_ID,
@@ -152,9 +152,11 @@ export default {
       );
       if (updateResult.affected === 0) throw new Error(NOT_FOUND);
 
-      const notiTitle = '참가완료';
-      const notiAbout = '참가신청이 수락되었어요';
-      await createStudyNoti(studyId, targetUserId, notiTitle, notiAbout, 105);
+      if (process.env.NODE_ENV !== 'test') {
+        const notiTitle = '참가완료';
+        const notiAbout = '스터디의 참가신청이 수락되었어요:)';
+        await createStudyNoti(studyId, targetUserId, notiTitle, notiAbout, 105);
+      }
 
       res.json({ message: OK });
     } catch (e) {
@@ -207,9 +209,11 @@ export default {
 
       // 호스트가 참가신청 취소해버린 경우
       /*
-      const notiTitle = '참가 취소';
-      const notiAbout = '스터디의 참가가 취소되었습니다';
-      await createStudyNoti(studyid, userId, notiTitle, notiAbout, 106);
+      if (process.env.NODE_ENV !== 'test') {
+        const notiTitle = '참가 취소';
+        const notiAbout = '스터디의 참가신청이 취소되었어요:(';
+        await createStudyNoti(studyid, userId, notiTitle, notiAbout, 106);
+      }
       */
 
       res.json({ message: '참가신청 취소 성공' });


### PR DESCRIPTION
- 아직 테스트코드 작성 전이라 전부 통일해서 'test' 일 때는 알림 생성되지 않도록 했습니다.
- 스터디 마감된 경우의 케이스(type: 107) 참여상태와 미참여상태 사용자에게 모두 알림이 가는 케이스도 추가되었습니다.
<br>

- profile join하는 작업 후 알림 메세지들 마저 마무리할 예정입니다.
- 일단 기획문서에 나와있는 그대로 알림메세지 등록해놓기는 했는데, 프론트에서 그대로 가져다가 쓸지 아니면 백에서는 필요한 정보만 넘기고 프론트에서 처리할지는 한 번 이야기해보면 좋을 것 같습니다.