### PR TITLE
비밀번호 재설정 api 추가

### DIFF
--- a/src/routes/study/study.controller.ts
+++ b/src/routes/study/study.controller.ts
@@ -166,7 +166,7 @@ const updateStudy = async (req: Request, res: Response) => {
 
   try {
     const { studyid } = req.params;
-  
+
     if (!Object.keys(req.body).length) throw new Error(BAD_REQUEST);
     const allowedFields = [
       'title',

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -21,7 +21,7 @@ router.delete('/', checkToken, controller.deleteUser);
 router.get('/', checkToken, controller.getUser);
 router.patch('/password', controller.updatePassword);
 router.use('/:id/role', roleRouter);
-router.patch('/:token/password', controller.saveChangedPassword);
+router.patch('/:id/password', controller.saveChangedPassword);
 router.patch('/:id', controller.updateUserInfo);
 
 export default router;

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -19,7 +19,9 @@ router.use('/study/applied', checkToken, controller.getAppliedStudies);
 router.post('/', controller.saveUser);
 router.delete('/', checkToken, controller.deleteUser);
 router.get('/', checkToken, controller.getUser);
+router.patch('/password', controller.updatePassword);
 router.use('/:id/role', roleRouter);
+router.patch('/:token/password', controller.saveChangedPassword);
 router.patch('/:id', controller.updateUserInfo);
 
 export default router;

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -50,10 +50,9 @@ export default {
     const NOT_FOUND = '가입되지 않은 사용자';
 
     try {
-      const { portalId } = req.body;
-      if (!portalId) throw new Error(BAD_REQUEST);
+      const { email } = req.body;
+      if (!email) throw new Error(BAD_REQUEST);
 
-      const email = `${portalId}@cau.ac.kr`;
       const user = await findUserByEmail(email);
       if (!user) throw new Error(NOT_FOUND);
 
@@ -61,7 +60,7 @@ export default {
       await updateTokenById(user.id, newToken);
       if (process.env.NODE_ENV !== 'test') {
         await sendMail(
-          `${portalId}@cau.ac.kr`,
+          email,
           '비밀번호 재설정을 완료해주세요',
           passwordResetContent(email, newToken)
         );

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -46,7 +46,7 @@ export default {
   },
   async updatePassword(req: Request, res: Response) {
     const OK = '비밀번호 재설정 요청 성공';
-    const BAD_REQUEST = '요청 body에 portalId가 포함되지 않음';
+    const BAD_REQUEST = '요청 body에 email이 포함되지 않음';
     const NOT_FOUND = '가입되지 않은 사용자';
 
     try {
@@ -79,7 +79,7 @@ export default {
   async saveChangedPassword(req: Request, res: Response) {
     const OK = '비밀번호 재설정 성공';
     const BAD_REQUEST = '요청 body에 email 또는 password가 포함되지 않음';
-    const NOT_FOUND = '해당 토큰을 가진 사용자가 존재하지 않음';
+    const NOT_FOUND = '해당 id를 가진 사용자가 존재하지 않음';
 
     try {
       const { email, password: newPassword } = req.body;
@@ -311,9 +311,9 @@ export default {
  *       schema:
  *         type: object
  *         properties:
- *           portalId:
+ *           email:
  *             type: string
- *             example: "testadmin1"
+ *             example: "testadmin1@cau.ac.kr"
  *
  *     responses:
  *       200:
@@ -325,13 +325,13 @@ export default {
  *               type: string
  *               example: "비밀번호 재설정 요청 성공"
  *       400:
- *         description: "요청 body에 portalId가 포함되지 않음"
+ *         description: "요청 body에 email이 포함되지 않음"
  *         schema:
  *           type: object
  *           properties:
  *             message:
  *               type: string
- *               example: "요청 body에 portalId가 포함되지 않음"
+ *               example: "요청 body에 email이 포함되지 않음"
  *       404:
  *         description: "사용자의 portalId에 연결된 중앙대이메일이 데이터베이스에 존재하지 않은 경우"
  *         schema:
@@ -341,7 +341,7 @@ export default {
  *               type: string
  *               example: "가입되지 않은 사용자"
  *
- * /api/user/{token}/password:
+ * /api/user/{id}/password:
  *   patch:
  *     tags:
  *     - user
@@ -349,9 +349,9 @@ export default {
  *     description: "비밀번호를 수정하기 위한 메일 인증을 요청하기 위한 엔드포인트입니다"
  *     parameters:
  *     - in: "path"
- *       name: "token"
+ *       name: "id"
  *       type: string
- *       description: "회원정보를 수정할 사용자에게 발급된 토큰"
+ *       description: "회원정보를 수정할 사용자의 id값"
  *       required: true
  *     - in: "body"
  *       name: "body"
@@ -384,22 +384,14 @@ export default {
  *             message:
  *               type: string
  *               example: "요청 body에 email 또는 password가 포함되지 않음"
- *       403:
- *         description: "토큰 관련 에러 발생"
- *         schema:
- *           type: object
- *           properties:
- *             message:
- *               type: string
- *               example: "토큰 검증 실패"
  *       404:
- *         description: "해당 토큰을 가진 사용자가 존재하지 않음"
+ *         description: "해당 id를 가진 사용자가 존재하지 않음"
  *         schema:
  *           type: object
  *           properties:
  *             message:
  *               type: string
- *               example: "해당 토큰을 가진 사용자가 존재하지 않음"
+ *               example: "해당 id를 가진 사용자가 존재하지 않음"
  */
 
 /**

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -41,7 +41,7 @@ export default {
   },
   async updatePassword(req: Request, res: Response) {
     const OK = '비밀번호 재설정 요청 성공';
-    const BAD_REQUEST = '요청 body에 email이 포함되지 않음';
+    const BAD_REQUEST = '요청 body에 portalId가 포함되지 않음';
     const NOT_FOUND = '가입되지 않은 사용자';
 
     try {
@@ -296,25 +296,23 @@ export default {
 
 /**
  * @swagger
- * /api/user/{userid}:
+ * /api/user/password:
  *   patch:
  *     tags:
  *     - user
- *     summary: "회원정보 수정"
- *     description: "사용자의 인증정보를 업데이트하기 위한 엔드포인트입니다. 유저 리프레시토큰, 비밀번호 등의 항목이 해당됩니다."
+ *     summary: "비밀번호 수정 요청"
+ *     description: "비밀번호를 수정하기 위한 메일 인증을 요청하기 위한 엔드포인트입니다"
  *     parameters:
- *     - in: "path"
- *       name: "userid"
- *       type: string
- *       format: uuid
- *       description: "회원정보를 수정할 사용자의 id"
- *       required: true
  *     - in: "body"
  *       name: "body"
- *       description: "회원정보를 수정할 사용자의 정보 객체"
+ *       description: "사용자의 이메일 인증을 위한 중앙대 포탈"
  *       required: true
  *       schema:
- *         $ref: "#/definitions/User"
+ *         type: object
+ *         properties:
+ *           portalId:
+ *             type: string
+ *             example: "testadmin1"
  *
  *     responses:
  *       200:
@@ -324,23 +322,83 @@ export default {
  *           properties:
  *             message:
  *               type: string
- *               example: "회원정보 수정 성공"
+ *               example: "비밀번호 재설정 요청 성공"
  *       400:
- *         description: "요청값이 유효하지 않은 경우입니다"
+ *         description: "요청 body에 portalId가 포함되지 않음"
  *         schema:
  *           type: object
  *           properties:
  *             message:
  *               type: string
- *               example: "회원정보 수정 실패"
+ *               example: "요청 body에 portalId가 포함되지 않음"
  *       404:
- *         description: "전달된 userid값이 데이터베이스에 없는 경우입니다"
+ *         description: "사용자의 portalId에 연결된 중앙대이메일이 데이터베이스에 존재하지 않은 경우"
  *         schema:
  *           type: object
  *           properties:
  *             message:
  *               type: string
- *               example: "일치하는 userid값이 없음"
+ *               example: "가입되지 않은 사용자"
+ *
+ * /api/user/{token}/password:
+ *   patch:
+ *     tags:
+ *     - user
+ *     summary: "비밀번호 수정 요청"
+ *     description: "비밀번호를 수정하기 위한 메일 인증을 요청하기 위한 엔드포인트입니다"
+ *     parameters:
+ *     - in: "path"
+ *       name: "token"
+ *       type: string
+ *       description: "회원정보를 수정할 사용자에게 발급된 토큰"
+ *       required: true
+ *     - in: "body"
+ *       name: "body"
+ *       description: "변경할 사용자의 정보"
+ *       required: true
+ *       schema:
+ *         type: object
+ *         properties:
+ *           email:
+ *             type: string
+ *             example: "testadmin1@cau.ac.kr"
+ *           password:
+ *             type: string
+ *             example: "changedpassword1234"
+ *
+ *     responses:
+ *       200:
+ *         description: "올바른 요청"
+ *         schema:
+ *           type: object
+ *           properties:
+ *             message:
+ *               type: string
+ *               example: "비밀번호 재설정 성공"
+ *       400:
+ *         description: "요청 body에 email 또는 password가 포함되지 않음"
+ *         schema:
+ *           type: object
+ *           properties:
+ *             message:
+ *               type: string
+ *               example: "요청 body에 email 또는 password가 포함되지 않음"
+ *       403:
+ *         description: "토큰 관련 에러 발생"
+ *         schema:
+ *           type: object
+ *           properties:
+ *             message:
+ *               type: string
+ *               example: "토큰 검증 실패"
+ *       404:
+ *         description: "해당 토큰을 가진 사용자가 존재하지 않음"
+ *         schema:
+ *           type: object
+ *           properties:
+ *             message:
+ *               type: string
+ *               example: "해당 토큰을 가진 사용자가 존재하지 않음"
  */
 
 /**

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -62,7 +62,7 @@ export default {
         await sendMail(
           email,
           '비밀번호 재설정을 완료해주세요',
-          passwordResetContent(email, newToken)
+          passwordResetContent(email, user.id)
         );
       }
 

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -79,22 +79,15 @@ export default {
   async saveChangedPassword(req: Request, res: Response) {
     const OK = '비밀번호 재설정 성공';
     const BAD_REQUEST = '요청 body에 email 또는 password가 포함되지 않음';
-    const FORBIDDEN = '토큰 검증 실패';
     const NOT_FOUND = '해당 토큰을 가진 사용자가 존재하지 않음';
 
     try {
       const { email, password: newPassword } = req.body;
       if (!email || !newPassword) throw new Error(BAD_REQUEST);
 
-      const { token } = req.params;
-      const user = await findUserByToken(token);
+      const { id } = req.params;
+      const user = await findUserById(id);
       if (!user) throw new Error(NOT_FOUND);
-
-      const decoded = jwt.verify(
-        token,
-        process.env.SIGNUP_TOKEN_SECRET as string
-      ) as { id: string };
-      if (user.id !== decoded.id) throw new Error(FORBIDDEN);
 
       await updatePasswordById(user.id, newPassword);
       res.json({ message: OK });
@@ -105,7 +98,7 @@ export default {
       } else if (err.message === NOT_FOUND) {
         res.status(404).json({ message: NOT_FOUND });
       } else {
-        res.status(403).json({ message: FORBIDDEN });
+        res.status(500).json({ message: 'error' });
       }
     }
   },

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -15,6 +15,7 @@ import { sendMail } from '../../services/mail';
 import { makeSignUpToken } from '../../utils/auth';
 import { validateCAU } from '../../utils/mail';
 import { findAllIfParticipatedByUserId } from '../../services/studyUser';
+import { signupMailContent } from '../../utils/mail/html';
 
 export default {
   async saveUser(req: Request, res: Response) {
@@ -30,7 +31,7 @@ export default {
       const token = makeSignUpToken(id);
       // TODO: await의 나열보다 Promise.all 의 사용이 성능적인 이점이 있을까?
       await saveUser({ id, email, password, token });
-      const message = await sendMail(email, id, token);
+      const message = await sendMail(email, signupMailContent(id, token));
 
       res.status(201).json({ message, id });
     } catch (e) {

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -15,7 +15,7 @@ import { sendMail } from '../../services/mail';
 import { makeSignUpToken } from '../../utils/auth';
 import { validateCAU } from '../../utils/mail';
 import { findAllIfParticipatedByUserId } from '../../services/studyUser';
-import { signupMailContent } from '../../utils/mail/html';
+import { passwordResetContent, signupMailContent } from '../../utils/mail/html';
 
 export default {
   async saveUser(req: Request, res: Response) {
@@ -53,12 +53,15 @@ export default {
       const user = await findUserByEmail(email);
       if (!user) throw new Error(NOT_FOUND);
 
-      if (process.env.NODE_ENV !== 'test') {
-        sendMail(`${portalId}@cau.ac.kr`, user.id, user.token);
-      }
-
       const newToken = makeSignUpToken(user.id);
       await updateTokenById(user.id, newToken);
+      if (process.env.NODE_ENV !== 'test') {
+        await sendMail(
+          `${portalId}@cau.ac.kr`,
+          passwordResetContent(email, newToken)
+        );
+      }
+
       res.json({ message: OK });
     } catch (e) {
       const err = e as Error;

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -31,7 +31,11 @@ export default {
       const token = makeSignUpToken(id);
       // TODO: await의 나열보다 Promise.all 의 사용이 성능적인 이점이 있을까?
       await saveUser({ id, email, password, token });
-      const message = await sendMail(email, signupMailContent(id, token));
+      const message = await sendMail(
+        email,
+        '회원가입을 완료해주세요',
+        signupMailContent(id, token)
+      );
 
       res.status(201).json({ message, id });
     } catch (e) {
@@ -58,6 +62,7 @@ export default {
       if (process.env.NODE_ENV !== 'test') {
         await sendMail(
           `${portalId}@cau.ac.kr`,
+          '비밀번호 재설정을 완료해주세요',
           passwordResetContent(email, newToken)
         );
       }

--- a/src/services/mail/index.ts
+++ b/src/services/mail/index.ts
@@ -1,5 +1,4 @@
 import nodemailer from 'nodemailer';
-import { html } from './html';
 
 /**
  *
@@ -8,11 +7,7 @@ import { html } from './html';
  * @param token 메일인증을 위해 발급받은 토큰값
  * @returns 메일 전송과정에서 에러 발생시 Error 객체, 성공시 메일 전송 성공을 알리는 문자열을 가진 Promise 객체 반환
  */
-export const sendMail = async (
-  dest: string,
-  id: string,
-  token: string
-): Promise<string> => {
+export const sendMail = async (dest: string, html: string): Promise<string> => {
   const transporter = nodemailer.createTransport({
     host: 'smtp.gmail.com',
     secure: false,
@@ -26,7 +21,7 @@ export const sendMail = async (
     from: process.env.MAIL_USER,
     to: dest,
     subject: '회원가입을 완료해주세요',
-    html: html(id, token),
+    html,
   };
 
   return new Promise((resolve, reject) => {

--- a/src/services/mail/index.ts
+++ b/src/services/mail/index.ts
@@ -3,11 +3,15 @@ import nodemailer from 'nodemailer';
 /**
  *
  * @param dest 메일을 수신할 상대 이메일 주소
- * @param id 메일인증을 진행할 사용자의 id
- * @param token 메일인증을 위해 발급받은 토큰값
+ * @param title 메일의 제목으로 들어갈 문자열
+ * @param html 메일의 내용이 될 html 문자열
  * @returns 메일 전송과정에서 에러 발생시 Error 객체, 성공시 메일 전송 성공을 알리는 문자열을 가진 Promise 객체 반환
  */
-export const sendMail = async (dest: string, html: string): Promise<string> => {
+export const sendMail = async (
+  dest: string,
+  title: string,
+  html: string
+): Promise<string> => {
   const transporter = nodemailer.createTransport({
     host: 'smtp.gmail.com',
     secure: false,
@@ -20,7 +24,7 @@ export const sendMail = async (dest: string, html: string): Promise<string> => {
   const option = {
     from: process.env.MAIL_USER,
     to: dest,
-    subject: '회원가입을 완료해주세요',
+    subject: title,
     html,
   };
 

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -77,10 +77,11 @@ export const updateUserById = async (id: string, data: UpdateUserDTO) => {
 };
 
 export const updatePasswordById = async (id: string, newPassword: string) => {
+  const hashedPassword = bcrypt.hashSync(newPassword, 10);
   return await getRepository(User)
     .createQueryBuilder()
     .update()
-    .set({ password: newPassword })
+    .set({ password: hashedPassword })
     .where('ID = :id', { id })
     .execute();
 };

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -51,6 +51,13 @@ export const findUserById = async (id: string) => {
     .getOne();
 };
 
+export const findUserByToken = async (token: string) => {
+  return await getRepository(User)
+    .createQueryBuilder()
+    .select()
+    .where('TOKEN = :token', { token })
+    .getOne();
+};
 interface UpdateUserDTO {
   email: string;
   password: string;
@@ -65,6 +72,24 @@ export const updateUserById = async (id: string, data: UpdateUserDTO) => {
     .createQueryBuilder()
     .update()
     .set({ email, password, isLogout, token, role })
+    .where('ID = :id', { id })
+    .execute();
+};
+
+export const updatePasswordById = async (id: string, newPassword: string) => {
+  return await getRepository(User)
+    .createQueryBuilder()
+    .update()
+    .set({ password: newPassword })
+    .where('ID = :id', { id })
+    .execute();
+};
+
+export const updateTokenById = async (id: string, token: string) => {
+  return await getRepository(User)
+    .createQueryBuilder()
+    .update()
+    .set({ token })
     .where('ID = :id', { id })
     .execute();
 };

--- a/src/utils/mail/html.ts
+++ b/src/utils/mail/html.ts
@@ -74,7 +74,7 @@ const _link = (id: string, token: string) =>
     ],
   });
 
-const _passwordResetLink = (email: string, token: string) =>
+const _passwordResetLink = (email: string, id: string) =>
   _createElement({
     tagName: 'a',
     className: 'button',
@@ -83,7 +83,7 @@ const _passwordResetLink = (email: string, token: string) =>
     attr: [
       [
         'href',
-        `https://github.com/caulipse/caulipse-server?email=${email}&token=${token}`,
+        `https://github.com/caulipse/caulipse-server?email=${email}&id=${id}`,
       ], // TODO: 우리 서비스 주소로 리다이렉트
       ['target', '_blank'],
     ],

--- a/src/utils/mail/html.ts
+++ b/src/utils/mail/html.ts
@@ -74,7 +74,7 @@ const _link = (id: string, token: string) =>
     ],
   });
 
-const _container = (id: string, token: string) =>
+const _signupContainer = (id: string, token: string) =>
   _createElement({
     tagName: 'div',
     className: 'container',
@@ -89,7 +89,7 @@ const _container = (id: string, token: string) =>
     children: [_greeting(), _instruction(), _link(id, token)],
   });
 
-export const html = (id: string, token: string) =>
+export const signupMailContent = (id: string, token: string) =>
   _createElement({
     tagName: 'div',
     className: 'body',
@@ -98,5 +98,5 @@ export const html = (id: string, token: string) =>
       ['padding', '0'],
       ['margin', '0'],
     ],
-    children: [_container(id, token)],
+    children: [_signupContainer(id, token)],
   });

--- a/src/utils/mail/html.ts
+++ b/src/utils/mail/html.ts
@@ -27,10 +27,10 @@ const _greeting = () =>
       ['font-size', '18px'],
       ['font-weight', '900'],
     ],
-    children: ['<h2>~~님 환영합니다!</h2>'],
+    children: ['<h2>환영합니다!</h2>'],
   });
 
-const _instruction = () =>
+const _instruction = (context: string) =>
   _createElement({
     tagName: 'div',
     className: 'instruction',
@@ -38,7 +38,7 @@ const _instruction = () =>
       ['margin', '8px 0 64px 0'],
       ['font-size', '16px'],
     ],
-    children: ['<span>인증 버튼을 눌러 회원가입을 완료하세요</span>'],
+    children: [`<span>인증 버튼을 눌러 ${context}을 완료하세요</span>`],
   });
 
 const _button = () =>
@@ -74,6 +74,21 @@ const _link = (id: string, token: string) =>
     ],
   });
 
+const _passwordResetLink = (email: string, token: string) =>
+  _createElement({
+    tagName: 'a',
+    className: 'button',
+    styles: [['text-decoration', 'none']],
+    children: [_button()],
+    attr: [
+      [
+        'href',
+        `https://github.com/caulipse/caulipse-server?email=${email}&token=${token}`,
+      ], // TODO: 우리 서비스 주소로 리다이렉트
+      ['target', '_blank'],
+    ],
+  });
+
 const _signupContainer = (id: string, token: string) =>
   _createElement({
     tagName: 'div',
@@ -86,10 +101,29 @@ const _signupContainer = (id: string, token: string) =>
       ['text-align', 'center'],
       ['border-radius', '8px'],
     ],
-    children: [_greeting(), _instruction(), _link(id, token)],
+    children: [_greeting(), _instruction('회원가입'), _link(id, token)],
   });
 
-export const signupMailContent = (id: string, token: string) =>
+const _passwordResetContainer = (id: string, token: string) =>
+  _createElement({
+    tagName: 'div',
+    className: 'container',
+    styles: [
+      ['max-width', '500px'],
+      ['margin', '0 auto'],
+      ['padding', '32px'],
+      ['background-color', '#f8f8f8'],
+      ['text-align', 'center'],
+      ['border-radius', '8px'],
+    ],
+    children: [
+      _greeting(),
+      _instruction('비밀번호 재설정'),
+      _passwordResetLink(id, token),
+    ],
+  });
+
+export const signupMailContent = (email: string, token: string) =>
   _createElement({
     tagName: 'div',
     className: 'body',
@@ -98,5 +132,17 @@ export const signupMailContent = (id: string, token: string) =>
       ['padding', '0'],
       ['margin', '0'],
     ],
-    children: [_signupContainer(id, token)],
+    children: [_signupContainer(email, token)],
+  });
+
+export const passwordResetContent = (email: string, token: string) =>
+  _createElement({
+    tagName: 'div',
+    className: 'body',
+    styles: [
+      ['width', '100%'],
+      ['padding', '0'],
+      ['margin', '0'],
+    ],
+    children: [_passwordResetContainer(email, token)],
   });

--- a/test/password.test.ts
+++ b/test/password.test.ts
@@ -39,14 +39,12 @@ describe('비밀번호 재설정 요청 api', () => {
   test('가입되지 않은 portalId를 body에 포함시켜 요청을 보내면 404 코드로 응답한다', async () => {
     const res = await request(app)
       .patch('/api/user/password')
-      .send({ portalId: 'falsyportalid' });
+      .send({ email: 'falsyportalid@cau.ac.kr' });
     expect(res.statusCode).toBe(404);
   });
 
   test('정상적인 요청을 보내면 데이터베이스의 token 필드를 갱신하고 200 코드로 응답한다', async () => {
-    const res = await request(app)
-      .patch('/api/user/password')
-      .send({ portalId: 'example' });
+    const res = await request(app).patch('/api/user/password').send({ email });
 
     const updatedUser = await conn
       .getRepository(User)

--- a/test/password.test.ts
+++ b/test/password.test.ts
@@ -1,0 +1,110 @@
+import app from '../src';
+import { randomUUID } from 'crypto';
+import request from 'supertest';
+import { Connection, ConnectionOptions, createConnection } from 'typeorm';
+import { db } from '../src/config/db';
+import { saveUser } from '../src/services/user';
+import User from '../src/entity/UserEntity';
+import { makeSignUpToken } from '../src/utils/auth';
+
+let conn: Connection;
+let newToken: string;
+const initialToken = '';
+const email = 'example@cau.ac.kr';
+const password = 'test';
+
+beforeAll(async () => {
+  conn = await createConnection({
+    ...db,
+    database: process.env.DB_DATABASE_TEST,
+  } as ConnectionOptions);
+
+  saveUser({ id: randomUUID(), email, password, token: initialToken });
+});
+
+afterAll(async () => {
+  await conn.getRepository(User).createQueryBuilder().delete().execute();
+  conn.close();
+});
+
+describe('비밀번호 재설정 요청 api', () => {
+  test('요청 body에 포탈 id를 포함시키지 않으면 400 코드로 응답한다', async () => {
+    const res = await request(app)
+      .patch('/api/user/password')
+      .send({ data: 'asdf' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('가입되지 않은 portalId를 body에 포함시켜 요청을 보내면 404 코드로 응답한다', async () => {
+    const res = await request(app)
+      .patch('/api/user/password')
+      .send({ portalId: 'falsyportalid' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('정상적인 요청을 보내면 데이터베이스의 token 필드를 갱신하고 200 코드로 응답한다', async () => {
+    const res = await request(app)
+      .patch('/api/user/password')
+      .send({ portalId: 'example' });
+
+    const updatedUser = await conn
+      .getRepository(User)
+      .createQueryBuilder()
+      .select()
+      .where('EMAIL = :email', { email })
+      .execute();
+    newToken = updatedUser.token;
+
+    expect(res.statusCode).toBe(200);
+    expect(newToken).not.toBe(initialToken);
+  });
+});
+
+describe('비밀번호 재설정 마무리 api', () => {
+  test('요청 body에 이메일 또는 패스워드가 포함되지 않을 시 400 코드로 응답한다', async () => {
+    const res = await request(app)
+      .patch(`/api/user/${newToken}/password`)
+      .send({ field: false });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('데이터베이스에 존재하지 않는 토큰을 요청에 포함할 시 403 코드로 응답한다', async () => {
+    const invalidToken = 'askdfjosadjfokjo';
+    const res = await request(app)
+      .patch(`/api/user/${invalidToken}/password`)
+      .send({ email, password: 'asdf' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('올바른 요청일 경우 사용자의 비밀번호를 전달된 비밀번호로 업데이트한다', async () => {
+    const newPassword = 'updated';
+    const id = randomUUID();
+    const token = makeSignUpToken(id);
+    const email2 = 'asdf@cau.ac.kr';
+
+    await conn
+      .getRepository(User)
+      .createQueryBuilder()
+      .insert()
+      .values({
+        id: id,
+        email: email2,
+        password: 'test',
+        isLogout: false,
+        token,
+      })
+      .execute();
+    const res = await request(app)
+      .patch(`/api/user/${token}/password`)
+      .send({ email: email2, password: newPassword });
+    const updatedUser = await conn
+      .getRepository(User)
+      .createQueryBuilder()
+      .select()
+      .where('ID = :id', { id })
+      .getOne();
+
+    expect(res.statusCode).toBe(200);
+    expect(updatedUser?.password).toBe(newPassword);
+  });
+});

--- a/test/password.test.ts
+++ b/test/password.test.ts
@@ -6,6 +6,7 @@ import { db } from '../src/config/db';
 import { saveUser } from '../src/services/user';
 import User from '../src/entity/UserEntity';
 import { makeSignUpToken } from '../src/utils/auth';
+import bcrypt from 'bcrypt';
 
 let conn: Connection;
 let newToken: string;
@@ -103,8 +104,10 @@ describe('비밀번호 재설정 마무리 api', () => {
       .select()
       .where('ID = :id', { id })
       .getOne();
+    if (!updatedUser) throw new Error();
+    const compareHash = bcrypt.compareSync(newPassword, updatedUser.password);
 
     expect(res.statusCode).toBe(200);
-    expect(updatedUser?.password).toBe(newPassword);
+    expect(compareHash).toBeTruthy();
   });
 });


### PR DESCRIPTION
#103 에서 언급한 것과 같이 유저의 정보 자체를 수정하는 것이 아니라 비밀번호 재설정을 위한 기능만을 제공하는 api로 리팩토링했습니다
그 과정에서 `PATCH /api/user/:userid` 에서 `PATCH /api/user/password`와 `PATCH /api/user/:id/password` 로 엔드포인트의 변경이 조금 있었습니다
이메일 인증을 위해 하나의 엔드포인트를 두 step으로 나눠서 요청을 받을 수 있도록 했고, 상세 구현은 아래와 같습니다

## 시나리오

- 사용자의 비밀번호 재설정 페이지 진입
- 본인 중앙대포탈 id 입력
- 서버에서 이메일 전송
- 이메일 화면에서 링크로 접속해 우리 서비스페이지로 이동
    - 서비스 페이지의 쿼리스트링에 토큰값 포함해 전송예정
- 이동된 서비스 페이지에서 변경할 비밀번호 입력 (PATCH `/api/user/:id/password`)
- 변경할 비밀번호 제출 시 데이터베이스에 반영

## 구현

- 중앙대메일 입력시 아래와 같은 요청 전송
    - `email` 을 입력받아 메일 전송
    
    ```tsx
    PATCH /api/user/password
    {
    	"email": "asdf@cau.ac.kr"
    }
    ```
    
    - 비밀번호 재설정을 위한 이메일 전송완료시 응답코드 200
    - 요청 body에 email이 포함되지 않을 시 응답코드 400
    - 가입되지 않은 이메일일시 응답코드 404
- 메일에 포함된 링크로 이동시 `https://caustudy.com/user/password?email={email}&id={id}` 같은 주소로 이동 예정
- 해당 주소에서 변경할 비밀번호는 아래와 같이 요청 전송
    - id, email 값은 쿼리스트링에서 가져오고, password 는 사용자의 입력으로 받음
    
    ```tsx
    PATCH /api/user/:id/password
    {
    	"email": "asdf@cau.ac.kr",
    	"password": "abcdef"
    }
    ```
    
    - 비밀번호 재설정 성공시 응답코드 200
    - 요청 body에 email 또는 password가 포함되지 않을 시 응답코드 400
    - 요청에 포함된 id를 가진 사용자가 없을 경우 응답코드 404
- 정상적인 요청일 시 데이터베이스의 password 필드 업데이트

현재 이메일에 전송되는 content와 스타일은 아래 사진과 같고, 위에서 언급드린것처럼 쿼리스트링에 `email`, `id` 정보를 붙여서 리다이렉션합니다
이 정보를 이용해 `/api/user/:id/password` 에 PATCH 요청을 보내주시면 최종적으로 비밀번호 재설정이 완료됩니다

<img width="772" alt="image" src="https://user-images.githubusercontent.com/61422890/163830825-961836ee-71f3-44d8-ae12-3625de7b1f69.png">

<img width="937" alt="image" src="https://user-images.githubusercontent.com/61422890/164934618-97bfc6e6-b7b2-4e42-aa83-a2b53e1775ee.png">

**지금은 버튼을 클릭하면 깃허브로 이동하도록 구현해뒀지만, 이후 우리 서비스로 리다이렉션 될 수 있도록 수정이 필요합니다**

(4/24 스펙 수정)