### PR TITLE
Feature/study user appliance

### DIFF
--- a/src/routes/study/index.ts
+++ b/src/routes/study/index.ts
@@ -20,7 +20,7 @@ router.get('/my-study', checkToken, controller.getMyStudy);
 router.patch('/:studyid/close', checkToken, controller.closeStudy);
 
 // 스터디 참가 신청 라우터
-router.use('/user/:studyid', studyUserRouter);
+router.use('/:studyid/user', studyUserRouter);
 // 스터디 북마크 라우터
 router.use('/:studyid/bookmark', checkToken, bookmarkRouter);
 // 스터디 문의글 라우터

--- a/src/routes/study/studyUser/index.ts
+++ b/src/routes/study/studyUser/index.ts
@@ -7,9 +7,10 @@ const router = Router({ mergeParams: true });
 router.get('/', checkToken, controller.getStudyUserList);
 router.post('/', checkToken, controller.joinStudy);
 router.patch('/', checkToken, controller.updateStudyJoin);
-router.delete('/', checkToken, controller.deleteStudyJoin);
 
 router.get('/participants', controller.getStudyParticipants);
 router.patch('/accept', checkToken, controller.acceptUser);
+
+router.delete('/:userid', checkToken, controller.deleteStudyJoin);
 
 export default router;

--- a/src/services/study/index.ts
+++ b/src/services/study/index.ts
@@ -342,6 +342,14 @@ export const closeStudy = async (study: Study) => {
   return await getRepository(Study).save(study);
 };
 
+export const findStudyByHostId = async (hostId: string) => {
+  return getRepository(Study)
+    .createQueryBuilder()
+    .select()
+    .where('HOST_ID = :id', { id: hostId })
+    .execute();
+};
+
 export default {
   countAllStudy,
   getAllStudy,
@@ -356,4 +364,5 @@ export default {
   decreaseMemberCount,
   increaseMemberCount,
   closeStudy,
+  findStudyByHostId,
 };

--- a/src/services/study/index.ts
+++ b/src/services/study/index.ts
@@ -326,8 +326,8 @@ export const increaseMemberCount = async (studyId: string) => {
     .createQueryBuilder()
     .update()
     .set({
-      membersCount: () => 'membersCount + 1',
-      vacancy: () => 'vacancy - 1',
+      membersCount: () => 'MEMBERS_COUNT + 1',
+      vacancy: () => 'VACANCY - 1',
     })
     .where('ID = :id', { id: studyId })
     .execute();

--- a/test/studyUser.test.ts
+++ b/test/studyUser.test.ts
@@ -66,7 +66,7 @@ beforeAll(async () => {
   mockStudy.isOpen = true;
   mockStudy.views = 0;
   mockStudy.bookmarkCount = 0;
-  mockStudy.dueDate = new Date(date.getTime() + 60 * 60 * 5);
+  mockStudy.dueDate = new Date(date.getTime() + 60 * 60 * 5).toString();
 
   await conn.getRepository(Study).save(mockStudy);
 });
@@ -127,7 +127,7 @@ describe('참가신청 api', () => {
 
     // when
     const res = await request(app)
-      .post(`/api/study/user/${studyId}`)
+      .post(`/api/study/${studyId}/user`)
       .set('Cookie', cookies)
       .send({ tempBio });
     const record = await conn
@@ -159,7 +159,7 @@ describe('참가신청 api', () => {
 
     // when
     const res = await request(app)
-      .post(`/api/study/user/${studyId}`)
+      .post(`/api/study/${studyId}/user`)
       .set('Cookie', cookies)
       .send();
     const record = await conn
@@ -187,7 +187,7 @@ describe('참가신청 api', () => {
 
     // when
     const res = await request(app)
-      .post(`/api/study/user/${studyId}`)
+      .post(`/api/study/${studyId}/user`)
       .send({ tempBio });
     const record = await conn
       .getRepository(StudyUser)
@@ -219,7 +219,7 @@ describe('참가신청 api', () => {
 
     // when
     const res = await request(app)
-      .post(`/api/study/user/${wrongStudyId}`)
+      .post(`/api/study/${wrongStudyId}/user`)
       .set('Cookie', cookies)
       .send({ tempBio });
     const record = await conn
@@ -238,7 +238,7 @@ describe('참가신청 수락대기중인 사용자 목록 조회 api', () => {
   const userId = randomUUID();
 
   test('로그인 하지 않았을 경우 401 코드로 응답한다', async () => {
-    const res = await request(app).get(`/api/study/user/${studyId}`);
+    const res = await request(app).get(`/api/study/${studyId}/user`);
     expect(res.statusCode).toBe(401);
   });
 
@@ -258,7 +258,7 @@ describe('참가신청 수락대기중인 사용자 목록 조회 api', () => {
     const wrongStudyId = 'asdjfalksdj';
 
     const res = await request(app)
-      .get(`/api/study/user/${wrongStudyId}`)
+      .get(`/api/study/${wrongStudyId}/user`)
       .set('Cookie', cookies);
 
     expect(res.statusCode).toBe(404);
@@ -273,7 +273,7 @@ describe('참가신청 수락대기중인 사용자 목록 조회 api', () => {
 
     // when
     const res = await request(app)
-      .get(`/api/study/user/${studyId}`)
+      .get(`/api/study/${studyId}/user`)
       .set('Cookie', cookies);
 
     // then
@@ -314,7 +314,7 @@ describe('참가신청 수락대기중인 사용자 목록 조회 api', () => {
         isOpen: true,
         views: 0,
         bookmarkCount: 0,
-        dueDate: new Date(date.getTime() + 60 * 60 * 5),
+        dueDate: new Date(date.getTime() + 60 * 60 * 5).toString(),
       })
       .execute();
 
@@ -325,7 +325,7 @@ describe('참가신청 수락대기중인 사용자 목록 조회 api', () => {
 
     // when
     const res = await request(app)
-      .get(`/api/study/user/${myStudyId}`)
+      .get(`/api/study/${myStudyId}/user`)
       .set('Cookie', cookies);
 
     // then
@@ -353,7 +353,7 @@ describe('참가신청 수락대기중인 사용자 목록 조회 api', () => {
     const cookies = loginRes.headers['set-cookie'];
 
     const res = await request(app)
-      .get(`/api/study/user/${studyId}`)
+      .get(`/api/study/${studyId}/user`)
       .set('Cookie', cookies);
 
     expect(res.statusCode).toBe(200);
@@ -366,7 +366,7 @@ describe('참가신청 수락대기중인 사용자 목록 조회 api', () => {
 describe('참가인원 조회 api', () => {
   test('로그인하지 않아도 401 코드로 응답하지 않는다', async () => {
     const res = await request(app)
-      .get(`/api/study/user/${studyId}/participants`)
+      .get(`/api/study/${studyId}/user/participants`)
       .send();
     expect(res.statusCode).not.toBe(401);
   });
@@ -377,7 +377,7 @@ describe('참가인원 조회 api', () => {
 
     // when
     const res = await request(app)
-      .get(`/api/study/user/${wrongStudyId}/participants`)
+      .get(`/api/study/${wrongStudyId}/user/participants`)
       .send();
 
     // then
@@ -402,12 +402,12 @@ describe('참가인원 조회 api', () => {
     study.isOpen = true;
     study.views = 0;
     study.bookmarkCount = 0;
-    study.dueDate = new Date(date.getTime() + 60 * 60 * 5);
+    study.dueDate = new Date(date.getTime() + 60 * 60 * 5).toString();
     await conn.getRepository(Study).save(study);
 
     // when
     const res = await request(app)
-      .get(`/api/study/user/${study.id}/participants`)
+      .get(`/api/study/${study.id}/user/participants`)
       .send();
 
     // then
@@ -439,7 +439,7 @@ describe('참가인원 조회 api', () => {
 
     // when
     const res = await request(app)
-      .get(`/api/study/user/${studyId}/participants`)
+      .get(`/api/study/${studyId}/user/participants`)
       .send();
 
     // then
@@ -452,7 +452,7 @@ describe('참가인원 조회 api', () => {
 describe('참가신청 수락/거절 api', () => {
   test('로그인하지 않았을 경우 401 코드로 응답한다', async () => {
     const res = await request(app)
-      .patch(`/api/study/user/${studyId}/accept`)
+      .patch(`/api/study/${studyId}/user/accept`)
       .send();
     expect(res.statusCode).toBe(401);
   });
@@ -468,7 +468,7 @@ describe('참가신청 수락/거절 api', () => {
 
     // when
     const res = await request(app)
-      .patch(`/api/study/user/${studyId}/accept`)
+      .patch(`/api/study/${studyId}/user/accept`)
       .set('Cookie', cookies)
       .send();
 
@@ -487,7 +487,7 @@ describe('참가신청 수락/거절 api', () => {
 
     // when
     const res = await request(app)
-      .patch(`/api/study/user/${studyId}/accept`)
+      .patch(`/api/study/${studyId}/user/accept`)
       .set('Cookie', cookies)
       .send({ accept: true, userId: mockUser1.id }); // README: 스터디 신청현황 테스트에서 mockUser1의 mockStudy에 대한 참가신청을 진행함
 
@@ -507,7 +507,7 @@ describe('참가신청 수락/거절 api', () => {
 
     // when
     const res = await request(app)
-      .patch(`/api/study/user/${wrongStudyId}/accept`)
+      .patch(`/api/study/${wrongStudyId}/user/accept`)
       .set('Cookie', cookies)
       .send({ accept: true, userId: mockUser1.id }); // README: 스터디 신청현황 테스트에서 mockUser1의 mockStudy에 대한 참가신청을 진행함
 
@@ -526,7 +526,7 @@ describe('참가신청 수락/거절 api', () => {
 
     // when
     const res = await request(app)
-      .patch(`/api/study/user/${studyId}/accept`)
+      .patch(`/api/study/${studyId}/user/accept`)
       .set('Cookie', cookies)
       .send({ accept: true, userId: mockUser2.id }); // README: 스터디 신청현황 테스트에서 mockUser1의 mockStudy에 대한 참가신청을 진행함
 
@@ -545,7 +545,7 @@ describe('참가신청 수락/거절 api', () => {
 
     // when
     const res = await request(app)
-      .patch(`/api/study/user/${studyId}/accept`)
+      .patch(`/api/study/${studyId}/user/accept`)
       .set('Cookie', cookies)
       .send({ accept: true, userId: mockUser1.id }); // README: 스터디 신청현황 테스트에서 mockUser1의 mockStudy에 대한 참가신청을 진행함
     const record = await conn
@@ -564,7 +564,7 @@ describe('참가신청 수락/거절 api', () => {
 
 describe('스터디 참가신청 수정 api', () => {
   test('로그인하지 않았을 경우 401 코드로 응답한다', async () => {
-    const res = await request(app).patch(`/api/study/user/${studyId}`).send();
+    const res = await request(app).patch(`/api/study/${studyId}/user`).send();
     expect(res.statusCode).toBe(401);
   });
 
@@ -579,7 +579,7 @@ describe('스터디 참가신청 수정 api', () => {
 
     // when
     const res = await request(app)
-      .patch(`/api/study/user/${studyId}`)
+      .patch(`/api/study/${studyId}/user`)
       .set('Cookie', cookies)
       .send();
 
@@ -599,7 +599,7 @@ describe('스터디 참가신청 수정 api', () => {
 
     // when
     const res = await request(app)
-      .patch(`/api/study/user/${wrongStudyId}`)
+      .patch(`/api/study/${wrongStudyId}/user`)
       .set('Cookie', cookies)
       .send({ tempBio: 'updatedTempBio' });
 
@@ -618,7 +618,7 @@ describe('스터디 참가신청 수정 api', () => {
 
     // when
     const res = await request(app)
-      .patch(`/api/study/user/${studyId}`)
+      .patch(`/api/study/${studyId}/user`)
       .set('Cookie', cookies)
       .send({ tempBio: 'updatedTempBio' }); // README: 스터디 신청현황 테스트에서 mockUser1의 mockStudy에 대한 참가신청을 진행함
 
@@ -638,7 +638,7 @@ describe('스터디 참가신청 수정 api', () => {
 
     // when
     const res = await request(app)
-      .patch(`/api/study/user/${studyId}`)
+      .patch(`/api/study/${studyId}/user`)
       .set('Cookie', cookies)
       .send({ tempBio: updatedTempBio }); // README: 스터디 신청현황 테스트에서 mockUser1의 mockStudy에 대한 참가신청을 진행함
     const record = await conn
@@ -657,7 +657,9 @@ describe('스터디 참가신청 수정 api', () => {
 
 describe('스터디 참가신청 취소 api', () => {
   test('로그인하지 않았을 경우 401 코드로 응답한다', async () => {
-    const res = await request(app).delete(`/api/study/user/${studyId}`);
+    const res = await request(app).delete(
+      `/api/study/${studyId}/user/${mockUser1.id}`
+    );
     expect(res.statusCode).toBe(401);
   });
 
@@ -673,7 +675,7 @@ describe('스터디 참가신청 취소 api', () => {
 
     // when
     const res = await request(app)
-      .delete(`/api/study/user/${wrongStudyId}`)
+      .delete(`/api/study/${wrongStudyId}/user/${mockUser1.id}`)
       .set('Cookie', cookies);
 
     // then
@@ -691,7 +693,7 @@ describe('스터디 참가신청 취소 api', () => {
 
     // when
     const res = await request(app)
-      .delete(`/api/study/user/${studyId}`)
+      .delete(`/api/study/${studyId}/user/${mockUser2.id}`)
       .set('Cookie', cookies);
 
     // then
@@ -719,7 +721,7 @@ describe('스터디 참가신청 취소 api', () => {
     // when
     const before = await query();
     const res = await request(app)
-      .delete(`/api/study/user/${studyId}`)
+      .delete(`/api/study/${studyId}/user/${mockUser1.id}`)
       .set('Cookie', cookies);
     const after = await query();
 

--- a/test/studyUser.test.ts
+++ b/test/studyUser.test.ts
@@ -66,7 +66,7 @@ beforeAll(async () => {
   mockStudy.isOpen = true;
   mockStudy.views = 0;
   mockStudy.bookmarkCount = 0;
-  mockStudy.dueDate = new Date(date.getTime() + 60 * 60 * 5).toString();
+  mockStudy.dueDate = new Date(date.getTime() + 60 * 60 * 5);
 
   await conn.getRepository(Study).save(mockStudy);
 });
@@ -402,7 +402,7 @@ describe('참가인원 조회 api', () => {
     study.isOpen = true;
     study.views = 0;
     study.bookmarkCount = 0;
-    study.dueDate = new Date(date.getTime() + 60 * 60 * 5).toString();
+    study.dueDate = new Date(date.getTime() + 60 * 60 * 5);
     await conn.getRepository(Study).save(study);
 
     // when


### PR DESCRIPTION
#102 의 스터디 참가신청 수락 및 거절 & 취소 관련 로직 구현입니다

- **스터디 참가신청 관련 엔드포인트를 `/api/study/user/:studyid` 에서 `/api/study/:studyid/user` 로 수정했습니다**
- 관련해서 테스트코드를 모두 수정했고 현재는 제 로컬에선 다 통과하는 상태입니다
- 참가신청 취소의 경우 스터디의 호스트 또는 신청자 본인이 수행할 수 있는데 호스트가 수행할 경우 대기자 명단으로 돌아가고, 신청자 본인이 수행할 경우 대기자 명단으로 돌아가지 않고 삭제되도록 구현했습니다
- 금방 끝날줄 알았는데 고치다보니 너무 늦어졌네요 -_-