### PR TITLE
Hotfix/studyuser swagger docs

### DIFF
--- a/src/routes/study/studyUser/studyUser.controller.ts
+++ b/src/routes/study/studyUser/studyUser.controller.ts
@@ -258,7 +258,7 @@ export default {
 
 /**
  * @swagger
- * /api/study/user/{studyid}:
+ * /api/study/{studyid}/user:
  *     get:
  *       tags:
  *       - study/user
@@ -479,7 +479,7 @@ export default {
  *                 type: string
  *                 example: "삭제 대상 참가신청이 없음"
  *
- * /api/study/user/{studyid}/participants:
+ * /api/study/{studyid}/user/participants:
  *   get:
  *     tags:
  *     - study/user
@@ -511,7 +511,7 @@ export default {
  *               type: string
  *               example: "일치하는 studyid가 없음"
  *
- * /api/study/user/{studyid}/accept:
+ * /api/study/{studyid}/user/accept:
  *   patch:
  *     tags:
  *     - study/user


### PR DESCRIPTION
Fix #133, #137 

`/api/study/user/{studyid}` -> `/api/study/{studyid}/user`
로직의 변경 없이 스웨거 문서만 수정했습니다. 혼란을 드려 죄송합니다 🙇
cc. @taechonkim 