### PR TITLE
Add routes for serving service page

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,10 @@ app.use(
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
+app.use(express.static('build'));
 
-app.use('/', rootRouter);
 app.use('/api-docs', swaggerUI.serve, swaggerUI.setup(swaggerSpec));
+app.use('/', rootRouter);
 
 if (process.env.NODE_ENV !== 'test') {
   createConnection(db)

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,11 +1,17 @@
-import { Router } from 'express';
+import { Request, Response, Router } from 'express';
 import userRouter from './user';
 import studyRouter from './study';
 import noticeRouter from './notice';
+import path from 'path';
 
 const router = Router();
 router.use('/api/user', userRouter);
 router.use('/api/study', studyRouter);
 router.use('/api/notice', noticeRouter);
+
+const page = path.resolve(__dirname, '../../build/index.html');
+router.get('*', (req: Request, res: Response) => {
+  res.sendFile(page);
+});
 
 export default router;


### PR DESCRIPTION
- 스웨거 링크에 접근가능하도록 수정
- 프론트엔드 빌드 결과물을 루트 도메인에서 serve 하도록 라우팅 구성
- serve 로직을 별도의 컨트롤러 파일로 분리하지 않고 라우터 파일에 함께 작성했는데, 이부분 의견 있으시면 말씀 부탁드립니다 :)