### PR TITLE
회원탈퇴가 불가능한 이슈 해결

### DIFF
--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -17,6 +17,7 @@ import { validateCAU } from '../../utils/mail';
 import { findAllIfParticipatedByUserId } from '../../services/studyUser';
 import { passwordResetContent, signupMailContent } from '../../utils/mail/html';
 import studyService from '../../services/study';
+import { deleteUserProfileByUserId } from '../../services/user/profile';
 
 export default {
   async saveUser(req: Request, res: Response) {
@@ -127,8 +128,10 @@ export default {
 
     try {
       const { id } = req.user as { id: string };
-      const result = await deleteUserById(id);
-      if (result.affected === 0) throw new Error(NOT_FOUND);
+      const profileDeleteResult = await deleteUserProfileByUserId(id);
+      const userDeleteResult = await deleteUserById(id);
+      if (profileDeleteResult.affected === 0 || userDeleteResult.affected === 0)
+        throw new Error(NOT_FOUND);
       res.json({ message: '회원 탈퇴 성공' });
     } catch (e) {
       if ((e as Error).message === NOT_FOUND) {

--- a/src/routes/user/user.controller.ts
+++ b/src/routes/user/user.controller.ts
@@ -132,6 +132,10 @@ export default {
       const userDeleteResult = await deleteUserById(id);
       if (profileDeleteResult.affected === 0 || userDeleteResult.affected === 0)
         throw new Error(NOT_FOUND);
+
+      res.clearCookie('accessToken');
+      res.clearCookie('refreshToken');
+
       res.json({ message: '회원 탈퇴 성공' });
     } catch (e) {
       if ((e as Error).message === NOT_FOUND) {

--- a/src/services/user/profile/index.ts
+++ b/src/services/user/profile/index.ts
@@ -126,3 +126,11 @@ export const updateUserProfile = async ({
     .execute();
   return result;
 };
+
+export const deleteUserProfileByUserId = async (id: string) => {
+  return await getRepository(UserProfile)
+    .createQueryBuilder()
+    .delete()
+    .where('USER_ID = :id', { id })
+    .execute();
+};


### PR DESCRIPTION
- 회원탈퇴가 불가능하던 이슈를 해결했습니다
- User 레코드를 삭제할때 관계되는 UserProfile 레코드를 먼저 삭제해주지 않아서 발생하는 이슈였습니다
- 추가로 회원탈퇴 api 호출 성공시 아래와 같은 에러 로그가 발생하는데, 프론트측 이슈로 생각되어 공유드립니다 @Jeyoung-Park @taechonkim 

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/61422890/170826760-cdb5a13e-9942-4842-bca5-e94e018d6d8f.png">
