### PR TITLE
토큰 갱신 로직의 쿠키 domain 속성 수정

### DIFF
--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -31,7 +31,7 @@ export const refresh = async (req: Request, res: Response) => {
     const hour = 3600 * 1000;
     res.cookie('accessToken', newAccessToken, {
       expires: new Date(Date.now() + 3 * hour),
-      domain: 'cau.rudy3091.com',
+      domain: 'caustudy.com',
       sameSite: 'none',
       secure: true,
     });


### PR DESCRIPTION
- 리프레시 토큰을 이용해 액세스 토큰을 갱신해줄 때 domain 속성을 `caustudy.com` 으로 수정했습니다