### PR TITLE
스터디 본문 길이 수정을 위한 DB 마이그레이션 설정 추가

### DIFF
--- a/ormconfig.js
+++ b/ormconfig.js
@@ -1,0 +1,14 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
+module.exports = {
+  type: 'mysql',
+  host: process.env.DB_HOST,
+  username: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_DATABASE,
+  migrations: ['dist/src/config/migration/*.js'],
+  cli: {
+    migrationsDir: 'src/config/migration',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "pm2:start": "pm2 start dist/src/index.js --name \"caulipse\"",
     "pm2:restart": "pm2 restart caulipse",
     "pm2:stop": "pm2 stop caulipse",
-    "mock:gen": "ts-node scripts/mock-gen.ts"
+    "mock:gen": "ts-node scripts/mock-gen.ts",
+    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js"
   },
   "dependencies": {
     "bcrypt": "^5.0.1",

--- a/src/config/migration/1656235988238-StudyLength.ts
+++ b/src/config/migration/1656235988238-StudyLength.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class StudyLength1656235988238 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE STUDY
+      MODIFY COLUMN STUDY_ABOUT VARCHAR(2000) NOT NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE STUDY
+      MODIFY COLUMN STUDY_ABOUT VARCHAR(255) NOT NULL;
+    `);
+  }
+}


### PR DESCRIPTION
- 변경사항 반영: `npm run typeorm migration:run`
- 변경사항 취소: `npm run typeorm migration:revert`